### PR TITLE
Include org.eclipse.birt.chart.osgi.runtime in birt-runtime-osgi

### DIFF
--- a/build/birt-packages/birt-runtime-osgi/reportengine.product
+++ b/build/birt-packages/birt-runtime-osgi/reportengine.product
@@ -169,6 +169,7 @@ United States, other countries, or both.
 
    <features>
       <feature id="org.eclipse.birt.engine.runtime"/>
+      <feature id="org.eclipse.birt.chart.osgi.runtime"/>
    </features>
 
    <configurations>


### PR DESCRIPTION
This ensures, for one thing, that javax.xml.soap is available.

https://github.com/eclipse-birt/birt/issues/1340