### PR TITLE
Copy more content into the lib folder of birt-runtime-osgi

### DIFF
--- a/build/birt-packages/birt-runtime-osgi/build.xml
+++ b/build/birt-packages/birt-runtime-osgi/build.xml
@@ -71,7 +71,10 @@
     </copy>
     <copy todir="${VIEWER_DIR}/WEB-INF/lib">
       <fileset dir="${ENGINE_DIR}/platform/plugins">
+        <include name="jakarta.xml.bind_*.jar"/>
         <include name="javax.wsdl_*.jar"/>
+        <include name="org.apache.commons.logging_*.jar"/>
+        <include name="org.apache.commons.discovery_*/lib/*.jar"/>
       </fileset>
       <fileset dir="${REPOSITORY_DIR}/plugins">
         <include name="javax.xml.soap_*.jar"/>


### PR DESCRIPTION
I.e., jakarta.xml.bind, org.apache.commons.logging, and org.apache.commons.discovery/*.jar

https://github.com/eclipse-birt/birt/issues/1340