### PR TITLE
Images with dimension unit percentage should be sized on the original  (#1401)

### DIFF
--- a/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/core/model/schematic/ImageHandleAdapter.java
+++ b/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/core/model/schematic/ImageHandleAdapter.java
@@ -129,7 +129,7 @@ public class ImageHandleAdapter extends ReportItemtHandleAdapter {
 
 	/**
 	 * Evaluate the size of the image based on px
-	 * 
+	 *
 	 * @param getRawSize return the real raw size
 	 * @return Return the requested size of the image (unit px)
 	 */
@@ -137,14 +137,13 @@ public class ImageHandleAdapter extends ReportItemtHandleAdapter {
 		int px = 0;
 		int py = 0;
 
-		DimensionHandle widthHandle = getImageHandle().getWidth();
+		DimensionHandle widthHandle = this.getImageHandle().getWidth();
 		if (this.imageFigureSize != null && DesignChoiceConstants.UNITS_PERCENTAGE.equals(widthHandle.getUnits())) {
 			px = (int) DEUtil.convertToPixel(widthHandle, this.imageFigureSize.width, DesignChoiceConstants.UNITS_PX);
 		} else {
 			px = (int) DEUtil.convertoToPixel(widthHandle);
 		}
-
-		DimensionHandle heightHandle = getImageHandle().getHeight();
+		DimensionHandle heightHandle = this.getImageHandle().getHeight();
 		if (this.imageFigureSize != null && DesignChoiceConstants.UNITS_PERCENTAGE.equals(heightHandle.getUnits())) {
 			py = (int) DEUtil.convertToPixel(heightHandle, this.imageFigureSize.height, DesignChoiceConstants.UNITS_PX);
 		} else {
@@ -158,6 +157,11 @@ public class ImageHandleAdapter extends ReportItemtHandleAdapter {
 			if (py == 0 && heightHandle.isSet()) {
 				py = 1;
 			}
+		}
+
+		// proportional scale of the image size
+		if (this.getImageHandle().isProportionalScale()) {
+			py = px;
 		}
 
 		// return the real raw size

--- a/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/core/model/schematic/ImageHandleAdapter.java
+++ b/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/core/model/schematic/ImageHandleAdapter.java
@@ -160,7 +160,7 @@ public class ImageHandleAdapter extends ReportItemtHandleAdapter {
 		}
 
 		// proportional scale of the image size
-		if (this.getImageHandle().isProportionalScale()) {
+		if (widthHandle.getUnits() != null && this.getImageHandle().isProportionalScale()) {
 			py = px;
 		}
 

--- a/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/core/model/schematic/ImageHandleAdapter.java
+++ b/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/core/model/schematic/ImageHandleAdapter.java
@@ -111,47 +111,28 @@ public class ImageHandleAdapter extends ReportItemtHandleAdapter {
 	/**
 	 * Gets size of image item. If the image size is 0, return null.
 	 *
-	 * @return the size of image item.
+	 * @return the size of image item (unit px)
 	 */
 	@Override
 	public Dimension getSize() {
 		return evaluateSize(false);
 	}
 
-	public Dimension get2Size() {
-		int px = 0;
-		int py = 0;
-
-		DimensionHandle widthHandle = getImageHandle().getWidth();
-		px = (int) DEUtil.convertoToPixel(widthHandle);
-
-		DimensionHandle heightHandle = getImageHandle().getHeight();
-		py = (int) DEUtil.convertoToPixel(heightHandle);
-
-		if (DEUtil.isFixLayout(getHandle())) {
-			if (px == 0 && widthHandle.isSet()) {
-				px = 1;
-			}
-			if (py == 0 && heightHandle.isSet()) {
-				py = 1;
-			}
-		}
-
-		if (px != 0 && py != 0) {
-			return new Dimension(px, py);
-		}
-		return null;
-	}
-
 	/**
 	 * Gets size of image item. Always returns a non-null value.
 	 *
-	 * @return Return the size of the image item
+	 * @return Return the size of the image item (unit px)
 	 */
 	public Dimension getRawSize() {
 		return evaluateSize(true);
 	}
 
+	/**
+	 * Evaluate the size of the image based on px
+	 * 
+	 * @param getRawSize return the real raw size
+	 * @return Return the requested size of the image (unit px)
+	 */
 	private Dimension evaluateSize(boolean getRawSize) {
 		int px = 0;
 		int py = 0;

--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/schematic/editparts/ImageEditPart.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/schematic/editparts/ImageEditPart.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import org.eclipse.birt.report.designer.core.model.SessionHandleAdapter;
 import org.eclipse.birt.report.designer.core.model.schematic.ImageHandleAdapter;
-import org.eclipse.birt.report.designer.core.util.mediator.request.ReportRequest;
+import org.eclipse.birt.report.designer.core.util.mediator.request.ReportRequestConstants;
 import org.eclipse.birt.report.designer.internal.ui.editors.schematic.border.LineBorder;
 import org.eclipse.birt.report.designer.internal.ui.editors.schematic.editpolicies.ReportComponentEditPolicy;
 import org.eclipse.birt.report.designer.internal.ui.editors.schematic.figures.ImageFigure;
@@ -97,7 +97,7 @@ public class ImageEditPart extends ReportElementEditPart implements IResourceEdi
 			public boolean understandsRequest(Request request) {
 				if (RequestConstants.REQ_DIRECT_EDIT.equals(request.getType())
 						|| RequestConstants.REQ_OPEN.equals(request.getType())
-						|| ReportRequest.CREATE_ELEMENT.equals(request.getType())) {
+						|| ReportRequestConstants.CREATE_ELEMENT.equals(request.getType())) {
 					return true;
 				}
 				return super.understandsRequest(request);
@@ -133,6 +133,9 @@ public class ImageEditPart extends ReportElementEditPart implements IResourceEdi
 		}
 
 		((ImageFigure) this.getFigure()).setImage(image);
+		if (((ImageFigure) this.getFigure()).getImage() != null) {
+			this.getImageAdapter().setImageFigureDimension(((ImageFigure) this.getFigure()).getImage().getBounds());
+		}
 
 		if (getImageAdapter().getSize() != null) {
 			this.getFigure().setSize(getImageAdapter().getSize());
@@ -189,7 +192,7 @@ public class ImageEditPart extends ReportElementEditPart implements IResourceEdi
 	@Override
 	public void performDirectEdit() {
 //		List dataSetList = DEUtil.getDataSetList( (DesignElementHandle) getModel( ) );
-		List dataSetList = DEUtil.getDataSetListExcludeSelf((DesignElementHandle) getModel());
+		List<?> dataSetList = DEUtil.getDataSetListExcludeSelf((DesignElementHandle) getModel());
 		ImageBuilder dialog = new ImageBuilder(PlatformUI.getWorkbench().getDisplay().getActiveShell(),
 				ImageBuilder.DLG_TITLE_EDIT, dataSetList);
 		dialog.setInput(getModel());

--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/schematic/figures/ImageFigure.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/editors/schematic/figures/ImageFigure.java
@@ -122,7 +122,7 @@ public class ImageFigure extends ReportElementFigure implements IOutsideBorder {
 	protected void paintFigure(Graphics graphics) {
 		if (isOpaque()) {
 			if (getBorder() instanceof BaseBorder) {
-				graphics.fillRectangle(getBounds().getCopy().crop(((BaseBorder) getBorder()).getBorderInsets()));
+				graphics.fillRectangle(getBounds().getCopy().shrink(((BaseBorder) getBorder()).getBorderInsets()));
 			} else {
 				graphics.fillRectangle(getBounds());
 			}

--- a/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/HTMLPerformanceOptimize.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/HTMLPerformanceOptimize.java
@@ -542,8 +542,19 @@ public class HTMLPerformanceOptimize extends HTMLEmitter {
 	@Override
 	public void buildImageStyle(IImageContent image, StringBuffer styleBuffer, int display) {
 		// image size
-		buildSize(styleBuffer, HTMLTags.ATTR_WIDTH, image.getWidth()); // $NON-NLS-1$
-		buildSize(styleBuffer, HTMLTags.ATTR_HEIGHT, image.getHeight()); // $NON-NLS-1$
+
+		DimensionType imgWidth = image.getWidth();
+		if (imgWidth != null && "%".equals(imgWidth.getUnits()) && image.getImageCalculatedSize().getWidth() > 0) {
+			imgWidth = new DimensionType(image.getImageCalculatedSize().getWidth(), "px");
+		}
+
+		DimensionType imgHeight = image.getHeight();
+		if (imgHeight != null && "%".equals(imgHeight.getUnits()) && image.getImageCalculatedSize().getHeight() > 0) {
+			imgHeight = new DimensionType(image.getImageCalculatedSize().getHeight(), "px");
+		}
+
+		buildSize(styleBuffer, HTMLTags.ATTR_WIDTH, imgWidth); // $NON-NLS-1$
+		buildSize(styleBuffer, HTMLTags.ATTR_HEIGHT, imgHeight); // $NON-NLS-1$
 		// build the value of display
 		// An image is indeed inline by default, and align itself on the text
 		// baseline with room for descenders. That caused the gap and extra height,

--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/AbstractEmitterImpl.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/AbstractEmitterImpl.java
@@ -1016,9 +1016,11 @@ public abstract class AbstractEmitterImpl {
 		String mimeType = image.getMIMEType();
 		String extension = image.getExtension();
 		String altText = image.getAltText();
-		double height = WordUtil.convertImageSize(image.getHeight(), 0, reportDpi);
-		int parentWidth = (int) (WordUtil.twipToPt(context.getCurrentWidth()) * reportDpi / 72);
-		double width = WordUtil.convertImageSize(image.getWidth(), parentWidth, reportDpi);
+		int referenceWidth = (int) (WordUtil.twipToPt(context.getCurrentWidth()) * reportDpi / 72);
+		int referenceHeight = 0;
+		
+		double width = WordUtil.convertImageSize(image.getWidth(), referenceWidth, reportDpi);
+		double height = WordUtil.convertImageSize(image.getHeight(), referenceHeight, reportDpi);
 		context.addContainer(false);
 
 		if (FlashFile.isFlash(mimeType, uri, extension)) {
@@ -1055,6 +1057,28 @@ public abstract class AbstractEmitterImpl {
 				float scale = ((float) imageInfo.getHeight()) / ((float) imageInfo.getWidth());
 				height = width * scale;
 			}
+System.out.println("==== standard ==== ");
+System.out.println("width: " + width);
+System.out.println("height: " + height);
+			if (image.getWidth() != null && DimensionType.UNITS_PERCENTAGE.equalsIgnoreCase(image.getWidth().getUnits())) {
+				referenceWidth = imageInfo.getWidth();
+				width = WordUtil.convertImageSize(image.getWidth(), referenceWidth,	PropertyUtil.getImageDpi(image, imageFileWidthDpi, 0));
+			}
+			if (image.getHeight() != null && DimensionType.UNITS_PERCENTAGE.equalsIgnoreCase(image.getHeight().getUnits())) {
+				referenceHeight = imageInfo.getHeight();
+				height = WordUtil.convertImageSize(image.getHeight(), referenceHeight, PropertyUtil.getImageDpi(image, imageFileHeightDpi, 0));
+			}
+			if (image.getWidth() == null && height > 0) {
+				width = height;
+			}
+			if (width > 0 && image.getHeight() == null) {
+				height = width;
+			}
+System.out.println("==== reference ==== ");
+System.out.println("imageInfo.getWidth(): " + imageInfo.getWidth() + ", referenceWidth: " + referenceWidth);
+System.out.println("imageInfo.getHeight(): " + imageInfo.getHeight() + ", referenceHeight: " + referenceHeight);
+System.out.println("width: " + width);
+System.out.println("height: " + height);
 
 			writeBookmark(image);
 			writeToc(image);

--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/AbstractEmitterImpl.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/AbstractEmitterImpl.java
@@ -1057,9 +1057,6 @@ public abstract class AbstractEmitterImpl {
 				float scale = ((float) imageInfo.getHeight()) / ((float) imageInfo.getWidth());
 				height = width * scale;
 			}
-System.out.println("==== standard ==== ");
-System.out.println("width: " + width);
-System.out.println("height: " + height);
 			if (image.getWidth() != null && DimensionType.UNITS_PERCENTAGE.equalsIgnoreCase(image.getWidth().getUnits())) {
 				referenceWidth = imageInfo.getWidth();
 				width = WordUtil.convertImageSize(image.getWidth(), referenceWidth,	PropertyUtil.getImageDpi(image, imageFileWidthDpi, 0));
@@ -1074,11 +1071,6 @@ System.out.println("height: " + height);
 			if (width > 0 && image.getHeight() == null) {
 				height = width;
 			}
-System.out.println("==== reference ==== ");
-System.out.println("imageInfo.getWidth(): " + imageInfo.getWidth() + ", referenceWidth: " + referenceWidth);
-System.out.println("imageInfo.getHeight(): " + imageInfo.getHeight() + ", referenceHeight: " + referenceHeight);
-System.out.println("width: " + width);
-System.out.println("height: " + height);
 
 			writeBookmark(image);
 			writeToc(image);

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/HTMLServerImageHandler.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/HTMLServerImageHandler.java
@@ -16,6 +16,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -31,9 +32,12 @@ public class HTMLServerImageHandler extends HTMLImageHandler {
 	protected Logger log = Logger.getLogger(HTMLServerImageHandler.class.getName());
 
 	private String handlerId;
+
 	private int count = 0;
 
-	private static HashMap map = new HashMap();
+	private static HashMap<String, Serializable> map = new HashMap<String, Serializable>();
+
+	private static HashMap<String, ImageSize> mapSize = new HashMap<String, ImageSize>();
 
 	/**
 	 * dummy constructor
@@ -174,6 +178,10 @@ public class HTMLServerImageHandler extends HTMLImageHandler {
 			mapID = getImageMapID(image);
 			if (map.containsKey(mapID)) {
 				synchronized (map) {
+					ImageSize rawSize = (ImageSize) mapSize.get(mapID);
+					if (rawSize != null) {
+						image.setImageRawSize(rawSize);
+					}
 					return (String) map.get(mapID);
 				}
 			}
@@ -210,6 +218,7 @@ public class HTMLServerImageHandler extends HTMLImageHandler {
 			if (needMap) {
 				synchronized (map) {
 					map.put(mapID, ret);
+					mapSize.put(mapID, image.getImageRawSize());
 				}
 			}
 

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/IImage.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/IImage.java
@@ -87,4 +87,14 @@ public interface IImage extends IReportPart {
 	 * @return the size of the image
 	 */
 	ImageSize getImageSize();
+
+	/**
+	 * @param rawSize image raw size
+	 */
+	void setImageRawSize(ImageSize rawSize);
+
+	/**
+	 * @return the size of the image
+	 */
+	ImageSize getImageRawSize();
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/ImageSize.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/ImageSize.java
@@ -14,26 +14,54 @@
 
 package org.eclipse.birt.report.engine.api;
 
+/**
+ * Class of image size
+ *
+ * @since 3.3
+ *
+ */
 public class ImageSize {
 
 	protected String unit;
 	protected float width;
 	protected float height;
 
+	/**
+	 * Constructor
+	 *
+	 * @param u unit of image size
+	 * @param w width of image
+	 * @param h height of image
+	 */
 	public ImageSize(String u, float w, float h) {
 		unit = u;
 		width = w;
 		height = h;
 	}
 
+	/**
+	 * Get the image size unit
+	 *
+	 * @return Return the image size unit
+	 */
 	public String getUnit() {
 		return unit;
 	}
 
+	/**
+	 * Get the image size width
+	 *
+	 * @return Return the image size width
+	 */
 	public float getWidth() {
 		return width;
 	}
 
+	/**
+	 * Get the image size height
+	 *
+	 * @return Return the image size height
+	 */
 	public float getHeight() {
 		return height;
 	}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/impl/Image.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/impl/Image.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.birt.report.engine.api.impl;
 
+import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
@@ -24,6 +25,8 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.imageio.ImageIO;
 
 import org.eclipse.birt.report.engine.api.IImage;
 import org.eclipse.birt.report.engine.api.ImageSize;
@@ -63,6 +66,8 @@ public class Image extends ReportPart implements IImage {
 	protected String imageMap;
 
 	protected ImageSize imageSize;
+
+	protected ImageSize imageRawSize;
 
 	/**
 	 * Constructor with an image uri
@@ -168,12 +173,13 @@ public class Image extends ReportPart implements IImage {
 			assert (false);
 		}
 
-	} /*
-		 * (non-Javadoc)
-		 *
-		 * @see org.eclipse.birt.report.engine.api2.IImage#getID()
-		 */
+	}
 
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.eclipse.birt.report.engine.api2.IImage#getID()
+	 */
 	@Override
 	public String getID() {
 		return id;
@@ -324,6 +330,12 @@ public class Image extends ReportPart implements IImage {
 					logger.log(Level.SEVERE, e.getMessage(), e);
 				}
 			}
+			try {
+				BufferedImage bImg = ImageIO.read(dest);
+				this.imageRawSize = new ImageSize("px", bImg.getWidth(), bImg.getHeight());
+			} catch (Exception ex) {
+				this.imageRawSize = new ImageSize("px", 0, 0);
+			}
 		}
 	}
 
@@ -368,5 +380,23 @@ public class Image extends ReportPart implements IImage {
 	@Override
 	public ImageSize getImageSize() {
 		return imageSize;
+	}
+
+	/**
+	 * Set the raw size of the image
+	 *
+	 * @param rawSize The raw image size
+	 */
+	public void setImageRawSize(ImageSize rawSize) {
+		this.imageRawSize = rawSize;
+	}
+
+	/**
+	 * Get the raw size of the image
+	 *
+	 * @return Return the raw size of the image
+	 */
+	public ImageSize getImageRawSize() {
+		return this.imageRawSize;
 	}
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/content/IImageContent.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/content/IImageContent.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.birt.report.engine.content;
 
+import org.eclipse.birt.report.engine.api.ImageSize;
+
 /**
  * Image content in the report.
  *
@@ -94,4 +96,32 @@ public interface IImageContent extends IContent {
 	int getResolution();
 
 	void setResolution(int resolution);
+
+	/**
+	 * Set the image raw size
+	 *
+	 * @param imageRawSize image raw size
+	 */
+	public void setImageRawSize(ImageSize imageRawSize);
+
+	/**
+	 * Get the image raw size
+	 *
+	 * @return Return the image raw size
+	 */
+	public ImageSize getImageRawSize();
+
+	/**
+	 * Set the calculated image size
+	 *
+	 * @param imageCalcSize calculated image size
+	 */
+	public void setImageCalculatedSize(ImageSize imageCalcSize);
+
+	/**
+	 * Get the calculated image size
+	 *
+	 * @return Return the calculated image size
+	 */
+	public ImageSize getImageCalculatedSize();
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/content/impl/ImageContent.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/content/impl/ImageContent.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.core.util.IOUtil;
+import org.eclipse.birt.report.engine.api.ImageSize;
 import org.eclipse.birt.report.engine.content.IContent;
 import org.eclipse.birt.report.engine.content.IContentVisitor;
 import org.eclipse.birt.report.engine.content.IImageContent;
@@ -27,6 +28,7 @@ import org.eclipse.birt.report.engine.ir.Expression;
 import org.eclipse.birt.report.engine.ir.ImageItemDesign;
 import org.eclipse.birt.report.engine.ir.Report;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
+import org.eclipse.birt.report.model.api.elements.DesignChoiceConstants;
 import org.eclipse.birt.report.model.api.elements.structures.EmbeddedImage;
 
 public class ImageContent extends AbstractContent implements IImageContent {
@@ -47,6 +49,12 @@ public class ImageContent extends AbstractContent implements IImageContent {
 	/** Resolution of the image */
 	private int resolution;
 
+	/** raw image size */
+	protected ImageSize imageRawSize = null;
+
+	/** calculated image size (e.g. relative image content) */
+	protected ImageSize imageCalcSize = null;
+
 	ImageContent(IImageContent image) {
 		super(image);
 		helpTextKey = image.getHelpKey();
@@ -56,6 +64,7 @@ public class ImageContent extends AbstractContent implements IImageContent {
 		data = image.getData();
 		imageMap = image.getImageMap();
 		MIMEType = image.getMIMEType();
+		imageRawSize = image.getImageRawSize();
 	}
 
 	@Override
@@ -408,5 +417,86 @@ public class ImageContent extends AbstractContent implements IImageContent {
 	@Override
 	public void setResolution(int resolution) {
 		this.resolution = resolution;
+	}
+
+	/**
+	 * Set the image raw size
+	 *
+	 * @param imageRawSize image raw size
+	 */
+	public void setImageRawSize(ImageSize imageRawSize) {
+		this.imageRawSize = imageRawSize;
+		this.setImageCalculatedSize(calculateImageSize());
+	}
+
+	/**
+	 * Calculate the image dimension of the image
+	 *
+	 * @param imageDimensionType image dimension type (0: width, 1: height)
+	 * @return Return the calculated image dimension in "px"
+	 */
+	private ImageSize calculateImageSize() {
+
+		double contentWidthValue = 100;
+		String contentWidthUnit = "%";
+
+		double contentHeightValue = 100;
+		String contentHeightUnit = "%";
+
+		double calculatedWidthValue = 200;
+		double calculatedHeightValue = 200;
+
+		if (this.getWidth() != null) {
+			contentWidthUnit = this.getWidth().getUnits();
+			contentWidthValue = this.getWidth().getMeasure();
+		}
+
+		if (this.getHeight() != null) {
+			contentHeightUnit = this.getHeight().getUnits();
+			contentHeightValue = this.getHeight().getMeasure();
+		}
+
+		if (this.imageRawSize != null) {
+
+			// calculate the image width size in "px"
+			if (DesignChoiceConstants.UNITS_PERCENTAGE.equals(contentWidthUnit)) {
+				calculatedWidthValue = (this.imageRawSize.getWidth() * contentWidthValue / 100);
+
+			}
+
+			// calculate the image height size in "px"
+			if (DesignChoiceConstants.UNITS_PERCENTAGE.equals(contentHeightUnit)) {
+				calculatedHeightValue = (this.imageRawSize.getHeight() * contentHeightValue / 100);
+
+			}
+		}
+		return new ImageSize("px", (float) calculatedWidthValue, (float) calculatedHeightValue);
+	}
+
+	/**
+	 * Get the image raw size
+	 *
+	 * @return Return the image raw size
+	 */
+	public ImageSize getImageRawSize() {
+		return this.imageRawSize;
+	}
+
+	/**
+	 * Set the calculated image size
+	 *
+	 * @param imageCalcSize calculated image size
+	 */
+	public void setImageCalculatedSize(ImageSize imageCalcSize) {
+		this.imageCalcSize = imageCalcSize;
+	}
+
+	/**
+	 * Get the calculated image size
+	 *
+	 * @return Return the calculated image size
+	 */
+	public ImageSize getImageCalculatedSize() {
+		return this.imageCalcSize;
 	}
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/internal/content/wrap/ImageContent.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/internal/content/wrap/ImageContent.java
@@ -15,6 +15,7 @@
 package org.eclipse.birt.report.engine.internal.content.wrap;
 
 import org.eclipse.birt.core.exception.BirtException;
+import org.eclipse.birt.report.engine.api.ImageSize;
 import org.eclipse.birt.report.engine.content.IContentVisitor;
 import org.eclipse.birt.report.engine.content.IImageContent;
 
@@ -160,4 +161,23 @@ public class ImageContent extends AbstractContentWrapper implements IImageConten
 		imageContent.setResolution(resolution);
 	}
 
+	@Override
+	public void setImageRawSize(ImageSize imageRawSize) {
+		imageContent.setImageRawSize(imageRawSize);
+	}
+
+	@Override
+	public ImageSize getImageRawSize() {
+		return imageContent.getImageRawSize();
+	}
+
+	@Override
+	public void setImageCalculatedSize(ImageSize imageCalcSize) {
+		imageContent.setImageCalculatedSize(imageCalcSize);
+	}
+
+	@Override
+	public ImageSize getImageCalculatedSize() {
+		return imageContent.getImageCalculatedSize();
+	}
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/ImageAreaLayout.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/ImageAreaLayout.java
@@ -218,11 +218,22 @@ public class ImageAreaLayout implements ILayout {
 			int imageFileDpiX = 0;
 			int imageFileDpiY = 0;
 
+			// prepare the raw image size
+			int referenceWidth = pWidth;
+			int referenceHeight = -1;
 			if (reader.getType() == ImageReader.TYPE_IMAGE_OBJECT
 					|| reader.getType() == ImageReader.TYPE_CONVERTED_SVG_OBJECT) {
 				if (imageObject != null) {
 					imageFileDpiX = imageObject.getDpiX();
 					imageFileDpiY = imageObject.getDpiY();
+
+					// set the raw image size like reference (used points)
+					referenceWidth = (int) (imageObject.getWidth()
+							/ PropertyUtil.getRenderDpi(content, context.getDpi())
+							* 72000d);
+					referenceHeight = (int) (imageObject.getHeight()
+							/ PropertyUtil.getRenderDpi(content, context.getDpi())
+							* 72000d);
 				}
 			}
 			resolutionX = PropertyUtil.getImageDpi(content, imageFileDpiX, context.getDpi());
@@ -234,9 +245,9 @@ public class ImageAreaLayout implements ILayout {
 				logger.log(Level.SEVERE, e.getLocalizedMessage());
 			}
 			int specifiedWidth = PropertyUtil.getImageDimensionValue(content, content.getWidth(), context.getDpi(),
-					pWidth);
+					referenceWidth);
 			int specifiedHeight = PropertyUtil.getImageDimensionValue(content, content.getHeight(), context.getDpi(),
-					-1);
+					referenceHeight);
 
 			Dimension dim = new Dimension(DEFAULT_WIDHT, DEFAULT_HEIGHT);
 			if (intrinsic == null) {

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/api/DimensionHandle.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/api/DimensionHandle.java
@@ -193,7 +193,7 @@ public class DimensionHandle extends ComplexValueHandle {
 	 */
 
 	public void setAbsolute(double value) throws SemanticException {
-		setValue(new Double(value));
+		setValue(Double.valueOf(value));
 	}
 
 	/**


### PR DESCRIPTION
Images with dimension unit percentage should be sized on the original image size (raster images: px of width and height) (#1401)