### PR TITLE
IPlatform:org.eclipse.birt.core.framework.Platform.platform is not in…

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.odp/META-INF/MANIFEST.MF
+++ b/engine/org.eclipse.birt.report.engine.emitter.odp/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 4.14.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.birt.report.engine;bundle-version="[2.1.0,5.0.0)",
- com.github.librepdf.openpdf;bundle-version="1.3.26",
+ com.github.librepdf.openpdf;bundle-version="[1.3.0,3.0.0)",
  org.eclipse.birt.report.engine.odf;bundle-version="4.13.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.birt.report.engine.emitter.odp.plugin.OdpEmitterPlugin

--- a/engine/org.eclipse.birt.report.engine.emitter.ppt/META-INF/MANIFEST.MF
+++ b/engine/org.eclipse.birt.report.engine.emitter.ppt/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.birt.core;bundle-version="[2.1.0,5.0.0)",
  org.eclipse.birt.report.engine;bundle-version="[2.1.0,5.0.0)",
  org.eclipse.birt.report.engine.fonts;bundle-version="[2.1.0,5.0.0)",
  org.apache.commons.codec;bundle-version="1.14.0",
- com.github.librepdf.openpdf;bundle-version="1.3.26"
+ com.github.librepdf.openpdf;bundle-version="[1.3.0,3.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.birt.report.engine.emitter.ppt.plugin.PPTEmitterPlugin
 Export-Package: org.eclipse.birt.report.engine.emitter.ppt,

--- a/engine/org.eclipse.birt.report.engine.emitter.pptx/META-INF/MANIFEST.MF
+++ b/engine/org.eclipse.birt.report.engine.emitter.pptx/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.birt.report.engine;bundle-version="[2.1.0,5.0.0)",
  org.eclipse.birt.report.engine.ooxml;bundle-version="[4.2.2,5.0.0)",
  org.eclipse.birt.report.engine.emitter.ppt;bundle-version="[3.7.2,5.0.0)",
- com.github.librepdf.openpdf;bundle-version="1.3.26"
+ com.github.librepdf.openpdf;bundle-version="[1.3.0,3.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.birt.report.engine.emitter.pptx.plugin.PPTXEmitterPlugin
 Export-Package: org.eclipse.birt.report.engine.emitter.pptx,

--- a/engine/org.eclipse.birt.report.engine.tests/META-INF/MANIFEST.MF
+++ b/engine/org.eclipse.birt.report.engine.tests/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.birt.core;bundle-version="[2.1.0,5.0.0)",
  org.eclipse.birt.report.engine;bundle-version="[2.1.0,5.0.0)",
  org.eclipse.birt.data;bundle-version="[2.1.0,5.0.0)",
- com.github.librepdf.openpdf;bundle-version="1.3.26",
+ com.github.librepdf.openpdf;bundle-version="[1.3.0,3.0.0)",
  org.eclipse.birt.report.data.adapter;bundle-version="[2.1.0,5.0.0)",
  org.eclipse.birt.report.engine.emitter.postscript;bundle-version="[2.1.0,5.0.0)",
  org.junit;bundle-version="4.13.0";resolution:=optional;visibility:=reexport,


### PR DESCRIPTION
IPlatform:org.eclipse.birt.core.framework.Platform.platform is not initializing after OSGi Platform Launcher successful startup #1281   Updated fixed version number with version range for openpdf