### PR TITLE
Remove ECF from products

### DIFF
--- a/UI/org.eclipse.birt.report.designer.ui.rcp/BIRT-headless.product
+++ b/UI/org.eclipse.birt.report.designer.ui.rcp/BIRT-headless.product
@@ -358,12 +358,6 @@ United States, other countries, or both.
       <plugin id="org.eclipse.e4.ui.workbench.renderers.swt"/>
       <plugin id="org.eclipse.e4.ui.workbench.swt"/>
       <plugin id="org.eclipse.e4.ui.workbench3"/>
-      <plugin id="org.eclipse.ecf"/>
-      <plugin id="org.eclipse.ecf.filetransfer"/>
-      <plugin id="org.eclipse.ecf.identity"/>
-      <plugin id="org.eclipse.ecf.provider.filetransfer"/>
-      <plugin id="org.eclipse.ecf.provider.filetransfer.ssl" fragment="true"/>
-      <plugin id="org.eclipse.ecf.ssl" fragment="true"/>
       <plugin id="org.eclipse.emf.common"/>
       <plugin id="org.eclipse.emf.ecore"/>
       <plugin id="org.eclipse.emf.ecore.change"/>

--- a/UI/org.eclipse.birt.report.designer.ui.rcp/BIRT.product
+++ b/UI/org.eclipse.birt.report.designer.ui.rcp/BIRT.product
@@ -361,12 +361,6 @@ United States, other countries, or both.
       <plugin id="org.eclipse.e4.ui.workbench.renderers.swt"/>
       <plugin id="org.eclipse.e4.ui.workbench.swt"/>
       <plugin id="org.eclipse.e4.ui.workbench3"/>
-      <plugin id="org.eclipse.ecf"/>
-      <plugin id="org.eclipse.ecf.filetransfer"/>
-      <plugin id="org.eclipse.ecf.identity"/>
-      <plugin id="org.eclipse.ecf.provider.filetransfer"/>
-      <plugin id="org.eclipse.ecf.provider.filetransfer.ssl" fragment="true"/>
-      <plugin id="org.eclipse.ecf.ssl" fragment="true"/>
       <plugin id="org.eclipse.emf.common"/>
       <plugin id="org.eclipse.emf.ecore"/>
       <plugin id="org.eclipse.emf.ecore.change"/>

--- a/build/birt-packages/birt-report-all-in-one/BIRT.product
+++ b/build/birt-packages/birt-report-all-in-one/BIRT.product
@@ -253,10 +253,6 @@ United States, other countries, or both.
       <feature id="org.eclipse.datatools.sqltools.doc.user" installMode="root"/>
       <feature id="org.eclipse.draw2d" installMode="root"/>
       <feature id="org.eclipse.e4.rcp" installMode="root"/>
-      <feature id="org.eclipse.ecf.core.feature" installMode="root"/>
-      <feature id="org.eclipse.ecf.core.ssl.feature" installMode="root"/>
-      <feature id="org.eclipse.ecf.filetransfer.feature" installMode="root"/>
-      <feature id="org.eclipse.ecf.filetransfer.ssl.feature" installMode="root"/>
       <feature id="org.eclipse.emf.codegen.ecore.ui" installMode="root"/>
       <feature id="org.eclipse.emf.codegen.ecore" installMode="root"/>
       <feature id="org.eclipse.emf.codegen.ui" installMode="root"/>

--- a/build/birt-packages/birt-report-rcp/BIRT.product
+++ b/build/birt-packages/birt-report-rcp/BIRT.product
@@ -252,10 +252,6 @@ United States, other countries, or both.
       <feature id="org.eclipse.datatools.sqltools.doc.user" installMode="root"/>
       <feature id="org.eclipse.draw2d" installMode="root"/>
       <feature id="org.eclipse.e4.rcp" installMode="root"/>
-      <feature id="org.eclipse.ecf.core.feature" installMode="root"/>
-      <feature id="org.eclipse.ecf.core.ssl.feature" installMode="root"/>
-      <feature id="org.eclipse.ecf.filetransfer.feature" installMode="root"/>
-      <feature id="org.eclipse.ecf.filetransfer.ssl.feature" installMode="root"/>
       <feature id="org.eclipse.emf.codegen.ecore.ui" installMode="root"/>
       <feature id="org.eclipse.emf.codegen.ecore" installMode="root"/>
       <feature id="org.eclipse.emf.codegen.ui" installMode="root"/>

--- a/build/org.eclipse.birt.releng/BIRT.setup
+++ b/build/org.eclipse.birt.releng/BIRT.setup
@@ -440,11 +440,11 @@
         <repository
             url="https://download.eclipse.org/cbi/updates/license"/>
         <repository
-            url="https://download.eclipse.org/oomph/simrel-orbit/2023-06"/>
+            url="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
         <repository
             url="https://download.eclipse.org/oomph/simrel-orbit-legacy/milestone/latest"/>
         <repository
-            url="https://download.eclipse.org/oomph/jetty/release/10.0.15"/>
+            url="https://download.eclipse.org/oomph/jetty/release/10.0.16"/>
         <repository
             url="https://download.eclipse.org/datatools/updates/milestone/latest"/>
         <repository

--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -1,34 +1,50 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from BIRT" sequenceNumber="17">
+<target name="Generated from BIRT" sequenceNumber="19">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
       <repository location="https://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <unit id="bcpg" version="0.0.0"/>
+      <unit id="bcprov" version="0.0.0"/>
+      <unit id="biz.aQute.bnd.util" version="0.0.0"/>
+      <unit id="biz.aQute.bndlib" version="0.0.0"/>
       <unit id="com.github.librepdf.openpdf" version="0.0.0"/>
       <unit id="com.google.gson" version="0.0.0"/>
       <unit id="com.google.guava" version="0.0.0"/>
       <unit id="com.google.guava.failureaccess" version="0.0.0"/>
       <unit id="com.google.javascript" version="0.0.0"/>
       <unit id="com.google.protobuf" version="0.0.0"/>
+      <unit id="com.ibm.icu" version="0.0.0"/>
       <unit id="com.jcraft.jsch" version="0.0.0"/>
       <unit id="com.sun.el.javax.el" version="0.0.0"/>
+      <unit id="com.sun.jna" version="0.0.0"/>
       <unit id="com.sun.jna.platform" version="0.0.0"/>
+      <unit id="jakarta.annotation-api" version="0.0.0"/>
       <unit id="jakarta.el" version="0.0.0"/>
       <unit id="jakarta.servlet-api" version="0.0.0"/>
       <unit id="jakarta.servlet.jsp" version="0.0.0"/>
-      <unit id="javax.activation" version="0.0.0"/>
-      <unit id="javax.annotation" version="0.0.0"/>
       <unit id="javax.el-api" version="0.0.0"/>
-      <unit id="javax.inject" version="0.0.0"/>
       <unit id="javax.servlet-api" version="0.0.0"/>
       <unit id="javax.servlet.jsp-api" version="0.0.0"/>
       <unit id="javax.wsdl" version="0.0.0"/>
-      <unit id="javax.xml.bind" version="0.0.0"/>
+      <unit id="junit-jupiter-api" version="0.0.0"/>
+      <unit id="junit-jupiter-engine" version="0.0.0"/>
+      <unit id="junit-jupiter-migrationsupport" version="0.0.0"/>
+      <unit id="junit-jupiter-params" version="0.0.0"/>
+      <unit id="junit-platform-commons" version="0.0.0"/>
+      <unit id="junit-platform-engine" version="0.0.0"/>
+      <unit id="junit-platform-launcher" version="0.0.0"/>
+      <unit id="junit-platform-runner" version="0.0.0"/>
+      <unit id="junit-platform-suite-api" version="0.0.0"/>
+      <unit id="junit-platform-suite-commons" version="0.0.0"/>
+      <unit id="junit-platform-suite-engine" version="0.0.0"/>
+      <unit id="junit-vintage-engine" version="0.0.0"/>
       <unit id="org.apache.ant" version="0.0.0"/>
       <unit id="org.apache.aries.spifly.dynamic.bundle" version="0.0.0"/>
+      <unit id="org.apache.axis.ant" version="0.0.0"/>
       <unit id="org.apache.batik.anim" version="0.0.0"/>
       <unit id="org.apache.batik.awt.util" version="0.0.0"/>
       <unit id="org.apache.batik.bridge" version="0.0.0"/>
@@ -46,25 +62,27 @@
       <unit id="org.apache.batik.transcoder" version="0.0.0"/>
       <unit id="org.apache.batik.util" version="0.0.0"/>
       <unit id="org.apache.batik.xml" version="0.0.0"/>
-      <unit id="org.apache.commons.codec" version="0.0.0"/>
       <unit id="org.apache.commons.collections4" version="0.0.0"/>
-      <unit id="org.apache.commons.compress" version="0.0.0"/>
-      <unit id="org.apache.commons.io" version="0.0.0"/>
-      <unit id="org.apache.commons.logging" version="0.0.0"/>
+      <unit id="org.apache.commons.commons-compress" version="0.0.0"/>
+      <unit id="org.apache.commons.commons-io" version="0.0.0"/>
+      <unit id="org.apache.commons.discovery" version="0.0.0"/>
       <unit id="org.apache.commons.math3" version="0.0.0"/>
       <unit id="org.apache.felix.gogo.command" version="0.0.0"/>
       <unit id="org.apache.felix.gogo.runtime" version="0.0.0"/>
       <unit id="org.apache.felix.gogo.shell" version="0.0.0"/>
       <unit id="org.apache.felix.scr" version="0.0.0"/>
-      <unit id="org.apache.httpcomponents.client5.httpclient5" version="0.0.0"/>
-      <unit id="org.apache.httpcomponents.client5.httpclient5-win" version="0.0.0"/>
-      <unit id="org.apache.httpcomponents.core5.httpcore5" version="0.0.0"/>
-      <unit id="org.apache.httpcomponents.core5.httpcore5-h2" version="0.0.0"/>
       <unit id="org.apache.httpcomponents.httpclient" version="0.0.0"/>
       <unit id="org.apache.httpcomponents.httpcore" version="0.0.0"/>
+      <unit id="org.apache.lucene.analysis-common" version="0.0.0"/>
+      <unit id="org.apache.lucene.analysis-smartcn" version="0.0.0"/>
+      <unit id="org.apache.lucene.core" version="0.0.0"/>
+      <unit id="org.apache.lucene.queries" version="0.0.0"/>
+      <unit id="org.apache.lucene.queryparser" version="0.0.0"/>
+      <unit id="org.apache.lucene.sandbox" version="0.0.0"/>
       <unit id="org.apache.poi" version="0.0.0"/>
       <unit id="org.apache.poi.ooxml" version="0.0.0"/>
       <unit id="org.apache.poi.ooxml.schemas" version="0.0.0"/>
+      <unit id="org.apache.wsil4j" version="0.0.0"/>
       <unit id="org.apache.xerces" version="0.0.0"/>
       <unit id="org.apache.xml.resolver" version="0.0.0"/>
       <unit id="org.apache.xmlbeans" version="0.0.0"/>
@@ -74,6 +92,8 @@
       <unit id="org.eclipse.jetty.servlet-api" version="0.0.0"/>
       <unit id="org.eclipse.orbit.mongodb" version="0.0.0"/>
       <unit id="org.hamcrest" version="0.0.0"/>
+      <unit id="org.hamcrest.core" version="0.0.0"/>
+      <unit id="org.junit" version="0.0.0"/>
       <unit id="org.mortbay.jasper.apache-el" version="0.0.0"/>
       <unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
       <unit id="org.mozilla.javascript" version="0.0.0"/>
@@ -82,6 +102,7 @@
       <unit id="org.objectweb.asm.tree" version="0.0.0"/>
       <unit id="org.objectweb.asm.tree.analysis" version="0.0.0"/>
       <unit id="org.objectweb.asm.util" version="0.0.0"/>
+      <unit id="org.opentest4j" version="0.0.0"/>
       <unit id="org.osgi.annotation.bundle" version="0.0.0"/>
       <unit id="org.osgi.annotation.versioning" version="0.0.0"/>
       <unit id="org.osgi.service.cm" version="0.0.0"/>
@@ -105,21 +126,23 @@
       <unit id="org.osgi.util.xml" version="0.0.0"/>
       <unit id="org.sat4j.core" version="0.0.0"/>
       <unit id="org.sat4j.pb" version="0.0.0"/>
-      <unit id="org.slf4j.api" version="0.0.0"/>
       <unit id="org.tukaani.xz" version="0.0.0"/>
-      <unit id="org.w3c.css.sac" version="0.0.0"/>
-      <unit id="org.w3c.dom.events" version="0.0.0"/>
-      <unit id="org.w3c.dom.smil" version="0.0.0"/>
-      <unit id="org.w3c.dom.svg" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/oomph/simrel-orbit/2023-06"/>
+      <unit id="org.uddi4j" version="0.0.0"/>
+      <unit id="slf4j.api" version="0.0.0"/>
+      <unit id="slf4j.simple" version="0.0.0"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <unit id="javax.activation" version="0.0.0"/>
+      <unit id="javax.annotation" version="0.0.0"/>
       <unit id="javax.el" version="0.0.0"/>
+      <unit id="javax.inject" version="0.0.0"/>
       <unit id="javax.mail" version="0.0.0"/>
       <unit id="javax.servlet" version="0.0.0"/>
       <unit id="javax.servlet.jsp" version="0.0.0"/>
       <unit id="javax.transaction" version="0.0.0"/>
       <unit id="javax.xml" version="0.0.0"/>
+      <unit id="javax.xml.bind" version="0.0.0"/>
       <unit id="javax.xml.soap" version="0.0.0"/>
       <unit id="javax.xml.stream" version="0.0.0"/>
       <unit id="net.sourceforge.lpg.lpgjavaruntime" version="0.0.0"/>
@@ -129,22 +152,30 @@
       <unit id="org.apache.lucene.analysis" version="0.0.0"/>
       <unit id="org.apache.lucene.core" version="0.0.0"/>
       <unit id="org.apache.xml.serializer" version="0.0.0"/>
+      <unit id="org.w3c.css.sac" version="0.0.0"/>
+      <unit id="org.w3c.dom.events" version="0.0.0"/>
+      <unit id="org.w3c.dom.smil" version="0.0.0"/>
+      <unit id="org.w3c.dom.svg" version="0.0.0"/>
       <repository location="https://download.eclipse.org/oomph/simrel-orbit-legacy/milestone/latest"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.jetty.apache-jsp" version="0.0.0"/>
       <unit id="org.eclipse.jetty.deploy" version="0.0.0"/>
+      <unit id="org.eclipse.jetty.http" version="0.0.0"/>
+      <unit id="org.eclipse.jetty.io" version="0.0.0"/>
       <unit id="org.eclipse.jetty.jndi" version="0.0.0"/>
       <unit id="org.eclipse.jetty.osgi.boot" version="0.0.0"/>
       <unit id="org.eclipse.jetty.plus" version="0.0.0"/>
+      <unit id="org.eclipse.jetty.security" version="0.0.0"/>
+      <unit id="org.eclipse.jetty.server" version="0.0.0"/>
+      <unit id="org.eclipse.jetty.servlet" version="0.0.0"/>
+      <unit id="org.eclipse.jetty.util" version="0.0.0"/>
+      <unit id="org.eclipse.jetty.util.ajax" version="0.0.0"/>
       <unit id="org.eclipse.jetty.webapp" version="0.0.0"/>
       <unit id="org.eclipse.jetty.xml" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/oomph/jetty/release/10.0.15"/>
+      <repository location="https://download.eclipse.org/oomph/jetty/release/10.0.16"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="org.apache.lucene.queries" version="0.0.0"/>
-      <unit id="org.apache.lucene.queryparser" version="0.0.0"/>
-      <unit id="org.apache.lucene.sandbox" version="0.0.0"/>
       <unit id="org.eclipse.datatools.common.doc.user.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.datatools.connectivity.doc.user.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.datatools.connectivity.feature.feature.group" version="0.0.0"/>
@@ -192,9 +223,8 @@
       <repository location="https://download.eclipse.org/tools/gef/classic/releases/latest"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="org.apache.axis.ant" version="0.0.0"/>
-      <unit id="org.apache.commons.discovery" version="0.0.0"/>
-      <unit id="org.apache.wsil4j" version="0.0.0"/>
+      <unit id="org.apache.commons.codec" version="0.0.0"/>
+      <unit id="org.apache.commons.logging" version="0.0.0"/>
       <unit id="org.eclipse.jem" version="0.0.0"/>
       <unit id="org.eclipse.jem.beaninfo" version="0.0.0"/>
       <unit id="org.eclipse.jem.beaninfo.vm" version="0.0.0"/>
@@ -286,7 +316,6 @@
       <unit id="org.eclipse.wst.wsdl.ui" version="0.0.0"/>
       <unit id="org.eclipse.wst.wsi.ui" version="0.0.0"/>
       <unit id="org.eclipse.wst.xml_userdoc.feature.feature.group" version="0.0.0"/>
-      <unit id="org.uddi4j" version="0.0.0"/>
       <repository location="https://download.eclipse.org/webtools/repository/latest"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -298,20 +327,12 @@
       <repository location="https://download.eclipse.org/justj/jres/17/updates/release/latest"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="bcpg" version="0.0.0"/>
-      <unit id="bcprov" version="0.0.0"/>
-      <unit id="biz.aQute.bnd.util" version="0.0.0"/>
-      <unit id="biz.aQute.bndlib" version="0.0.0"/>
-      <unit id="com.sun.jna" version="0.0.0"/>
-      <unit id="org.apache.lucene.analysis-common" version="0.0.0"/>
-      <unit id="org.apache.lucene.analysis-smartcn" version="0.0.0"/>
-      <unit id="org.apache.lucene.core" version="0.0.0"/>
       <unit id="org.eclipse.e4.tools.emf.ui" version="0.0.0"/>
       <unit id="org.eclipse.e4.tools.services" version="0.0.0"/>
       <unit id="org.eclipse.ecf.core.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.rcp.configuration.feature.group" version="0.0.0"/>

--- a/common/org.apache.batik.transcoder.birt.ext/META-INF/MANIFEST.MF
+++ b/common/org.apache.batik.transcoder.birt.ext/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Batik Transcoder Extension
 Bundle-SymbolicName: org.apache.batik.transcoder.birt.ext;singleton:=true
 Bundle-Version: 1.14.0.qualifier
-Fragment-Host: org.apache.batik.transcoder;bundle-version="[1.16.0,1.17.0)"
+Fragment-Host: org.apache.batik.transcoder;bundle-version="[1.17.0,1.18.0)"
 Bundle-Vendor: Eclipse BIRT
 Automatic-Module-Name: org.apache.batik.ext.awt.extension
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.apache.batik.codec;bundle-version="[1.16.0,1.17.0)"
+Require-Bundle: org.apache.batik.codec;bundle-version="[1.17.0,1.18.0)"

--- a/engine/uk.co.spudsoft.birt.emitters.excel/META-INF/MANIFEST.MF
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.birt.report.engine;bundle-version="4.13.0",
  org.apache.poi.ooxml;bundle-version="[4.1.1,5.0.0)",
  org.apache.poi.ooxml.schemas;bundle-version="[4.1.1,5.0.0)",
  org.apache.xmlbeans;bundle-version="[3.1.0,4.0.0)",
- org.apache.commons.compress;bundle-version="[1.19.0,2.0.0)"
+ org.apache.commons.commons-compress;bundle-version="[1.24.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  lib/commons-codec-1.5.jar


### PR DESCRIPTION
THe products are over-specified and include directly things that are also indirectly induced by other things.  In this case, the Platform's evolving use of ECF is causing a problem.

https://github.com/eclipse-birt/birt/pull/1433