### PR TITLE
Fix xlsx merge region overlap (#1455)

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/HTMLReportEmitter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/HTMLReportEmitter.java
@@ -3302,16 +3302,15 @@ public class HTMLReportEmitter extends ContentEmitterAdapter {
 		ReportDesignHandle design = (ReportDesignHandle) runnable.getDesignHandle();
 		URL url = design.findResource(uri, IResourceLocator.IMAGE, reportContext.getAppContext());
 		String fileExtension = null;
-
 		Module module = design.getModule();
-		BackgroundImageInfo backgroundImage = null;
+		ResourceLocatorWrapper rl = null;
+		ExecutionContext exeContext = ((ReportContent) this.report).getExecutionContext();
+		if (exeContext != null) {
+			rl = exeContext.getResourceLocator();
+		}
+		BackgroundImageInfo backgroundImage = new BackgroundImageInfo("", null, 0, 0, 0, 0, rl, module);
 
 		if (isBackground && imageStyle != null) {
-			ResourceLocatorWrapper rl = null;
-			ExecutionContext exeContext = ((ReportContent) this.report).getExecutionContext();
-			if (exeContext != null) {
-				rl = exeContext.getResourceLocator();
-			}
 			String uriString = EmitterUtil.getBackgroundImageUrl(imageStyle, design,
 					this.report.getReportContext() == null ? null : this.report.getReportContext().getAppContext());
 
@@ -3375,7 +3374,9 @@ public class HTMLReportEmitter extends ContentEmitterAdapter {
 			default:
 				assert (false);
 			}
-			backgroundImage.setUri(imgUri);
+			if (backgroundImage != null) {
+				backgroundImage.setUri(imgUri);
+			}
 		}
 		return backgroundImage;
 	}

--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/AbstractRealTableCellHandler.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/AbstractRealTableCellHandler.java
@@ -150,7 +150,20 @@ public class AbstractRealTableCellHandler extends CellContentHandler {
 				// endRow, state.colNum + offset, endCol + offset );
 				CellRangeAddress newMergedRegion = new CellRangeAddress(state.rowNum, endRow, column,
 						column + cell.getColSpan() - 1);
-				state.currentSheet.addMergedRegion(newMergedRegion);
+
+				Boolean newAddressRange = true;
+				for (CellRangeAddress addedMergedRegion : state.currentSheet.getMergedRegions()) {
+					if (addedMergedRegion.getFirstRow() == newMergedRegion.getFirstRow()
+							&& addedMergedRegion.getFirstColumn() == newMergedRegion.getFirstColumn()
+							&& addedMergedRegion.getLastRow() == newMergedRegion.getLastRow()
+							&& addedMergedRegion.getLastColumn() == newMergedRegion.getLastColumn()) {
+						newAddressRange = false;
+						break;
+					}
+				}
+				if (newAddressRange) {
+					state.currentSheet.addMergedRegion(newMergedRegion);
+				}
 
 				colSpan = cell.getColSpan();
 			}


### PR DESCRIPTION
The issue fix the situation when the xlsx-emitter try to add a merged region with the identically range more like one times.
(The fix doesn't handle all situations of overlapping of merge regions.)