### PR TITLE
java.lang.NoClassDefFoundError when starting WebViewer #1451

### DIFF
--- a/common/org.apache.axis/META-INF/MANIFEST.MF
+++ b/common/org.apache.axis/META-INF/MANIFEST.MF
@@ -76,6 +76,12 @@ Import-Package: javax.activation;resolution:=optional,
  javax.servlet;version="2.4.0";resolution:=optional,
  javax.servlet.http;version="2.4.0";resolution:=optional,
  javax.xml.rpc;version="1.1.0",
+ javax.xml.rpc.encoding;version="1.1.0",
+ javax.xml.rpc.handler;version="1.1.0",
+ javax.xml.rpc.handler.soap;version="1.1.0",
+ javax.xml.rpc.holders;version="1.1.0",
+ javax.xml.rpc.server;version="1.1.0",
+ javax.xml.rpc.soap;version="1.1.0",
  org.apache.commons.logging;version="[1.0.4,2.0.0)";resolution:=optional,
  org.apache.commons.logging.impl;version="[1.0.4,2.0.0)";resolution:=optional
 Bundle-ManifestVersion: 2


### PR DESCRIPTION
Added missing Import-Package: headers to "our" version of Axis 1.4.1

I do not know the state of the Axis in Orbit. It has the correct import statements but I do not know if it contains the fixes for the vulnerabilities mentioned in #662, which made us build our own version of Axis.
