### PR TITLE
Fix excel-issue of removed row then remove also regsitered merge regions from sheet (#1455)

### DIFF
--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/AbstractRealTableCellHandler.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/AbstractRealTableCellHandler.java
@@ -146,11 +146,27 @@ public class AbstractRealTableCellHandler extends CellContentHandler {
 						"]");
 				log.debug("Should be merging ? [", state.rowNum, ",", column, "] to [", endRow, ",",
 						column + cell.getColSpan() - 1, "]");
-				// CellRangeAddress newMergedRegion = new CellRangeAddress( state.rowNum,
-				// endRow, state.colNum + offset, endCol + offset );
 				CellRangeAddress newMergedRegion = new CellRangeAddress(state.rowNum, endRow, column,
 						column + cell.getColSpan() - 1);
-				state.currentSheet.addMergedRegion(newMergedRegion);
+
+				// excel merge region, avoid registration of overlapped merge regions
+				Boolean newAddressRange = true;
+				for (CellRangeAddress registeredMergedRegion : state.currentSheet.getMergedRegions()) {
+					if (newMergedRegion.getFirstColumn() >= registeredMergedRegion.getFirstColumn()
+							&& newMergedRegion.getFirstColumn() <= registeredMergedRegion.getLastColumn()
+							&& newMergedRegion.getFirstRow() >= registeredMergedRegion.getFirstRow()
+							&& newMergedRegion.getFirstRow() <= registeredMergedRegion.getLastRow()
+							|| registeredMergedRegion.getFirstRow() == newMergedRegion.getFirstRow()
+									&& registeredMergedRegion.getFirstColumn() == newMergedRegion.getFirstColumn()
+									&& registeredMergedRegion.getLastRow() == newMergedRegion.getLastRow()
+									&& registeredMergedRegion.getLastColumn() == newMergedRegion.getLastColumn()) {
+						newAddressRange = false;
+						break;
+					}
+				}
+				if (newAddressRange) {
+					state.currentSheet.addMergedRegion(newMergedRegion);
+				}
 
 				colSpan = cell.getColSpan();
 			}

--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/AbstractRealTableRowHandler.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/handlers/AbstractRealTableRowHandler.java
@@ -16,10 +16,12 @@
 package uk.co.spudsoft.birt.emitters.excel.handlers;
 
 import java.util.Iterator;
+import java.util.List;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.util.CellRangeAddress;
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.content.IRowContent;
 import org.eclipse.birt.report.engine.ir.DimensionType;
@@ -181,6 +183,23 @@ public abstract class AbstractRealTableRowHandler extends AbstractHandler {
 		if (blankRow || ((!rowHasNestedTable) && (!isNested()) && (currentRow.getPhysicalNumberOfCells() == 0))) {
 			log.debug("Removing row ", currentRow.getRowNum());
 			state.currentSheet.removeRow(currentRow);
+
+			/*
+			 * row verification whether the row is registered with merged cells if yes, then
+			 * remove the merged region from sheet
+			 */
+			int indexRemoveMergedRegion = -1;
+			List<CellRangeAddress> mergedRegions = state.currentSheet.getMergedRegions();
+			for (int index = 0; index < mergedRegions.size(); index++) {
+				CellRangeAddress registeredMergedRegion = mergedRegions.get(index);
+				if (registeredMergedRegion.getFirstRow() == state.rowNum) {
+					indexRemoveMergedRegion = index;
+					break;
+				}
+			}
+			if (indexRemoveMergedRegion >= 0) {
+				state.currentSheet.removeMergedRegion(indexRemoveMergedRegion);
+			}
 		} else {
 			DimensionType height = ((IRowContent) element).getHeight();
 			if (height != null) {


### PR DESCRIPTION
Fix the excel-issue if an blank row with merged cells will be removed then remove the registered merge area from the excel-sheet and also an additional double check is added to avoid overlapping merge registrations on the excel-sheet (#1455)