### PR TITLE
org.eclipse.birt.promote fails on master builds #1470

### DIFF
--- a/promotion/pom.xml
+++ b/promotion/pom.xml
@@ -91,17 +91,17 @@ SPDX-License-Identifier: EPL-2.0
                 -type ${build.type}
                 -downloads
                 ${project.basedir}/../build/birt-packages/birt-charts/target/birt-charts-${birt.version}-${maven.build.timestamp}.zip
-                ${project.basedir}/../build/birt-packages/birt-report-all-in-one/target/products/birt-report-designer-all-in-one-${birt.version}-${maven.build.timestamp}-linux.gtk.aarch64.zip
-                ${project.basedir}/../build/birt-packages/birt-report-all-in-one/target/products/birt-report-designer-all-in-one-${birt.version}-${maven.build.timestamp}-linux.gtk.x86_64.zip
-                ${project.basedir}/../build/birt-packages/birt-report-all-in-one/target/products/birt-report-designer-all-in-one-${birt.version}-${maven.build.timestamp}-macosx.cocoa.aarch64.zip
-                ${project.basedir}/../build/birt-packages/birt-report-all-in-one/target/products/birt-report-designer-all-in-one-${birt.version}-${maven.build.timestamp}-macosx.cocoa.x86_64.zip
+                ${project.basedir}/../build/birt-packages/birt-report-all-in-one/target/products/birt-report-designer-all-in-one-${birt.version}-${maven.build.timestamp}-linux.gtk.aarch64.tar.gz
+                ${project.basedir}/../build/birt-packages/birt-report-all-in-one/target/products/birt-report-designer-all-in-one-${birt.version}-${maven.build.timestamp}-linux.gtk.x86_64.tar.gz
+                ${project.basedir}/../build/birt-packages/birt-report-all-in-one/target/products/birt-report-designer-all-in-one-${birt.version}-${maven.build.timestamp}-macosx.cocoa.aarch64.tar.gz
+                ${project.basedir}/../build/birt-packages/birt-report-all-in-one/target/products/birt-report-designer-all-in-one-${birt.version}-${maven.build.timestamp}-macosx.cocoa.x86_64.tar.gz
                 ${project.basedir}/../build/birt-packages/birt-report-all-in-one/target/products/birt-report-designer-all-in-one-${birt.version}-${maven.build.timestamp}-win32.win32.x86_64.zip
                 ${project.basedir}/../build/birt-packages/birt-report-framework-sdk/target/birt-report-framework-sdk-${birt.version}-${maven.build.timestamp}.zip
                 ${project.basedir}/../build/birt-packages/birt-report-framework/target/birt-report-framework-${birt.version}-${maven.build.timestamp}.zip
-                ${project.basedir}/../build/birt-packages/birt-report-rcp/target/products/birt-rcp-report-designer-${birt.version}-${maven.build.timestamp}-linux.gtk.aarch64.zip
-                ${project.basedir}/../build/birt-packages/birt-report-rcp/target/products/birt-rcp-report-designer-${birt.version}-${maven.build.timestamp}-linux.gtk.x86_64.zip
-                ${project.basedir}/../build/birt-packages/birt-report-rcp/target/products/birt-rcp-report-designer-${birt.version}-${maven.build.timestamp}-macosx.cocoa.aarch64.zip
-                ${project.basedir}/../build/birt-packages/birt-report-rcp/target/products/birt-rcp-report-designer-${birt.version}-${maven.build.timestamp}-macosx.cocoa.x86_64.zip
+                ${project.basedir}/../build/birt-packages/birt-report-rcp/target/products/birt-rcp-report-designer-${birt.version}-${maven.build.timestamp}-linux.gtk.aarch64.tar.gz
+                ${project.basedir}/../build/birt-packages/birt-report-rcp/target/products/birt-rcp-report-designer-${birt.version}-${maven.build.timestamp}-linux.gtk.x86_64.tar.gz
+                ${project.basedir}/../build/birt-packages/birt-report-rcp/target/products/birt-rcp-report-designer-${birt.version}-${maven.build.timestamp}-macosx.cocoa.aarch64.tar.gz
+                ${project.basedir}/../build/birt-packages/birt-report-rcp/target/products/birt-rcp-report-designer-${birt.version}-${maven.build.timestamp}-macosx.cocoa.x86_64.tar.gz
                 ${project.basedir}/../build/birt-packages/birt-report-rcp/target/products/birt-rcp-report-designer-${birt.version}-${maven.build.timestamp}-win32.win32.x86_64.zip
                 ${project.basedir}/../build/birt-packages/birt-runtime-osgi/target/birt-runtime-osgi-${birt.version}-${maven.build.timestamp}.zip
                 ${project.basedir}/../build/birt-packages/birt-runtime/target/birt-runtime-${birt.version}-${maven.build.timestamp}.zip


### PR DESCRIPTION
Product archives for Linux and Mac have changed from zip files to tar.gz files. Currently org.eclipse.birt.promote fails since it still uses .zip for these files.