### PR TITLE
Improve the setup to generate a correct target platform

### DIFF
--- a/UI/org.eclipse.birt.report.designer.ui.rcp/BIRT-headless.product
+++ b/UI/org.eclipse.birt.report.designer.ui.rcp/BIRT-headless.product
@@ -206,8 +206,6 @@ United States, other countries, or both.
       <plugin id="org.apache.derby"/>
       <plugin id="org.apache.felix.scr"/>
       <plugin id="org.apache.jasper.glassfish"/>
-      <plugin id="org.apache.lucene.analysis"/>
-      <plugin id="org.apache.lucene.core"/>
       <plugin id="org.apache.poi"/>
       <plugin id="org.apache.xerces"/>
       <plugin id="org.apache.xml.resolver"/>

--- a/UI/org.eclipse.birt.report.designer.ui.rcp/BIRT.product
+++ b/UI/org.eclipse.birt.report.designer.ui.rcp/BIRT.product
@@ -206,8 +206,6 @@ United States, other countries, or both.
       <plugin id="org.apache.derby"/>
       <plugin id="org.apache.felix.scr"/>
       <plugin id="org.apache.jasper.glassfish"/>
-      <plugin id="org.apache.lucene.analysis"/>
-      <plugin id="org.apache.lucene.core"/>
       <plugin id="org.apache.poi"/>
       <plugin id="org.apache.xerces"/>
       <plugin id="org.apache.xml.resolver"/>

--- a/build/org.eclipse.birt.releng/BIRT.setup
+++ b/build/org.eclipse.birt.releng/BIRT.setup
@@ -13,7 +13,7 @@
     xmlns:setup.targlets="http://www.eclipse.org/oomph/setup/targlets/1.0"
     xmlns:setup.workingsets="http://www.eclipse.org/oomph/setup/workingsets/1.0"
     xmlns:workingsets="http://www.eclipse.org/oomph/workingsets/1.0"
-    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/setup/pde/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/PDE.ecore http://www.eclipse.org/oomph/predicates/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/projects/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore http://www.eclipse.org/oomph/setup/targlets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore"
+    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/JDT.ecore http://www.eclipse.org/oomph/setup/pde/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/PDE.ecore http://www.eclipse.org/oomph/predicates/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/projects/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Projects.ecore http://www.eclipse.org/oomph/setup/targlets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/workingsets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/WorkingSets.ecore"
     name="birt"
     label="BIRT">
   <annotation
@@ -416,7 +416,7 @@
         </detail>
         <detail
             key="generateVersions">
-          <value>false</value>
+          <value>jakarta.annotation-api|org.mortbay.jasper.apache-.*</value>
         </detail>
         <detail
             key="minimizeImplicitUnits">
@@ -444,7 +444,7 @@
         <repository
             url="https://download.eclipse.org/oomph/simrel-orbit-legacy/milestone/latest"/>
         <repository
-            url="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/nightly/latest"/>
+            url="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/release/latest"/>
         <repository
             url="https://download.eclipse.org/datatools/updates/milestone/latest"/>
         <repository
@@ -454,7 +454,7 @@
         <repository
             url="https://download.eclipse.org/webtools/repository/latest"/>
         <repository
-            url="https://download.eclipse.org/justj/epp/release/latest/"/>
+            url="https://download.eclipse.org/justj/epp/release/latest"/>
         <repository
             url="https://download.eclipse.org/justj/jres/17/updates/release/latest"/>
       </repositoryList>

--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from BIRT" sequenceNumber="23">
+<target name="Generated from BIRT" sequenceNumber="24">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
@@ -22,9 +22,8 @@
       <unit id="com.sun.jna" version="0.0.0"/>
       <unit id="com.sun.jna.platform" version="0.0.0"/>
       <unit id="com.zaxxer.sparsebits" version="0.0.0"/>
-      <unit id="jakarta.annotation-api" version="2.1.1"/>
       <unit id="jakarta.annotation-api" version="1.3.5"/>
-      <unit id="jakarta.enterprise.cdi-api" version="0.0.0"/>
+      <unit id="jakarta.annotation-api" version="2.1.1"/>
       <unit id="jakarta.inject.jakarta.inject-api" version="0.0.0"/>
       <unit id="jakarta.interceptor-api" version="0.0.0"/>
       <unit id="jakarta.servlet-api" version="0.0.0"/>
@@ -136,6 +135,7 @@
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <unit id="cdi.api" version="0.0.0"/>
       <unit id="javax.activation" version="0.0.0"/>
       <unit id="javax.annotation" version="0.0.0"/>
       <unit id="javax.el" version="0.0.0"/>
@@ -152,8 +152,6 @@
       <unit id="org.apache.commons.jxpath" version="0.0.0"/>
       <unit id="org.apache.derby" version="0.0.0"/>
       <unit id="org.apache.jasper.glassfish" version="0.0.0"/>
-      <unit id="org.apache.lucene.analysis" version="0.0.0"/>
-      <unit id="org.apache.lucene.core" version="0.0.0"/>
       <unit id="org.apache.xml.serializer" version="0.0.0"/>
       <unit id="org.eclipse.orbit.mongodb" version="0.0.0"/>
       <repository location="https://download.eclipse.org/oomph/simrel-orbit-legacy/milestone/latest"/>
@@ -175,7 +173,7 @@
       <unit id="org.eclipse.jetty.session" version="0.0.0"/>
       <unit id="org.eclipse.jetty.util" version="0.0.0"/>
       <unit id="org.eclipse.jetty.xml" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/nightly/latest"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/release/latest"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.apache.xerces" version="0.0.0"/>
@@ -331,7 +329,7 @@
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.justj.epp.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/justj/epp/release/latest/"/>
+      <repository location="https://download.eclipse.org/justj/epp/release/latest"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.justj.openjdk.hotspot.jre.full.feature.group" version="0.0.0"/>


### PR DESCRIPTION
Also remove unnecessary includes of lucene from products to help induce a more stable generated target platform.

https://github.com/eclipse-birt/birt/issues/1474