### PR TITLE
Fixes some UI strangeness in Birt Designer

### DIFF
--- a/chart/org.eclipse.birt.chart.ui.extension/src/org/eclipse/birt/chart/ui/swt/composites/FontCanvas.java
+++ b/chart/org.eclipse.birt.chart.ui.extension/src/org/eclipse/birt/chart/ui/swt/composites/FontCanvas.java
@@ -47,7 +47,6 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Event;
 
 /**
  * FontCanvas
@@ -94,10 +93,6 @@ public class FontCanvas extends Canvas implements PaintListener, DisposeListener
 		}
 		addDisposeListener(this);
 		addPaintListener(this);
-		GC gc = new GC(this);
-		Event e = new Event();
-		e.gc = gc;
-		notifyListeners(SWT.Paint, e);
 	}
 
 	public void setFontDefinition(FontDefinition fdSelected) {

--- a/core/org.eclipse.birt.core.ui/src/org/eclipse/birt/core/ui/frameworks/taskwizard/composites/MessageComposite.java
+++ b/core/org.eclipse.birt.core.ui/src/org/eclipse/birt/core/ui/frameworks/taskwizard/composites/MessageComposite.java
@@ -14,18 +14,17 @@
 package org.eclipse.birt.core.ui.frameworks.taskwizard.composites;
 
 import org.eclipse.birt.core.ui.utils.UIHelper;
+import org.eclipse.jface.resource.FontDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.DisposeEvent;
-import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.events.PaintListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
-import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Rectangle;
-import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Canvas;
@@ -36,7 +35,7 @@ import org.eclipse.swt.widgets.Label;
 /**
  *
  */
-public final class MessageComposite extends Composite implements PaintListener, DisposeListener {
+public final class MessageComposite extends Composite implements PaintListener {
 
 	/**
 	 *
@@ -58,22 +57,14 @@ public final class MessageComposite extends Composite implements PaintListener, 
 	/**
 	 *
 	 */
-	private Font foTitle = null;
-
-	/**
-	 *
-	 */
-	private Composite co = null;
-
-	/**
-	 *
-	 */
 	private Label laTitle = null, laDescription = null;
 
 	/**
 	 *
 	 */
 	private ImageCanvas ic = null;
+
+	private LocalResourceManager resourceManager;
 
 	/**
 	 *
@@ -108,7 +99,7 @@ public final class MessageComposite extends Composite implements PaintListener, 
 	@Override
 	public void setBackground(Color cBG) {
 		super.setBackground(cBG);
-		co.setBackground(cBG);
+
 		laTitle.setBackground(cBG);
 		laDescription.setBackground(cBG);
 		if (!bDisableImage) {
@@ -120,20 +111,20 @@ public final class MessageComposite extends Composite implements PaintListener, 
 	 *
 	 */
 	private void setup() {
-		setLayout(new FillLayout());
 
-		co = new Composite(this, SWT.NONE);
-		co.addPaintListener(this);
+		this.addPaintListener(this);
 		GridLayout gl = new GridLayout();
 		if (!bDisableImage) {
 			gl.numColumns = 2;
 		}
-		co.setLayout(gl);
+		setLayout(gl);
 
-		laTitle = new Label(co, SWT.WRAP);
-		final FontData fd = laTitle.getFont().getFontData()[0];
-		foTitle = new Font(Display.getCurrent(), fd.getName(), fd.getHeight(), SWT.BOLD);
-		laTitle.setFont(foTitle);
+		laTitle = new Label(this, SWT.WRAP);
+
+		this.resourceManager = new LocalResourceManager(JFaceResources.getResources(), this);
+		Font titleFont = this.resourceManager.createFont(FontDescriptor.createFrom(this.getFont()).setStyle(SWT.BOLD));
+
+		laTitle.setFont(titleFont);
 		laTitle.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_CYAN));
 
 		laTitle.setText(sTitle);
@@ -142,7 +133,7 @@ public final class MessageComposite extends Composite implements PaintListener, 
 		laTitle.setAlignment(SWT.CENTER);
 
 		if (!bDisableImage) {
-			ic = new ImageCanvas(co);
+			ic = new ImageCanvas(this);
 			gd = new GridData();
 			gd.verticalSpan = 2;
 			gd.verticalAlignment = GridData.BEGINNING;
@@ -150,7 +141,7 @@ public final class MessageComposite extends Composite implements PaintListener, 
 			ic.setLayoutData(gd);
 		}
 
-		laDescription = new Label(co, SWT.LEFT | SWT.WRAP | SWT.DRAW_TRANSPARENT);
+		laDescription = new Label(this, SWT.LEFT | SWT.WRAP | SWT.DRAW_TRANSPARENT);
 		laDescription.setText(sDescription);
 		gd = new GridData(GridData.FILL_BOTH);
 		gd.horizontalIndent = 10;
@@ -173,23 +164,6 @@ public final class MessageComposite extends Composite implements PaintListener, 
 		GC gc = pev.gc;
 		gc.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_GRAY));
 		gc.drawRectangle(rCA);
-	}
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.eclipse.swt.events.DisposeListener#widgetDisposed(org.eclipse.swt.events.
-	 * DisposeEvent)
-	 */
-	@Override
-	public void widgetDisposed(DisposeEvent dev) {
-		// Disposed by UIHelper
-		// if (!bDisableImage)
-		// {
-		// img.dispose();
-		// }
-		foTitle.dispose();
 	}
 
 	/**

--- a/core/org.eclipse.birt.core.ui/src/org/eclipse/birt/core/ui/swt/custom/TextCombo.java
+++ b/core/org.eclipse.birt.core.ui/src/org/eclipse/birt/core/ui/swt/custom/TextCombo.java
@@ -16,14 +16,12 @@ package org.eclipse.birt.core.ui.swt.custom;
 
 import java.util.HashMap;
 
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.graphics.Font;
-import org.eclipse.swt.graphics.FontData;
-import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 
 /**
  * Custom text combo
@@ -61,22 +59,17 @@ public class TextCombo extends CustomChooserComposite {
 	public TextCombo(Composite parent, int style) {
 		super(parent, style);
 
-		GC gc = new GC(this);
-		itemHeight = gc.getFontMetrics().getHeight() + 2;
+		/*
+		 * We are in the construct so the default font is used. - Grab the "bold"
+		 * default from the FontRegistry
+		 */
+		this.fontBold = JFaceResources.getFontRegistry().getBold(JFaceResources.DEFAULT_FONT);
 
-		if (gc.getFont().getFontData() == null || gc.getFont().getFontData().length == 0) {
-			fontBold = new Font(Display.getCurrent(), "arial", //$NON-NLS-1$
-					9, SWT.BOLD);
-		} else {
-			FontData fd = gc.getFont().getFontData()[0];
-			fontBold = new Font(gc.getDevice(), fd.getName(), fd.getHeight(), fd.getStyle() | SWT.BOLD);
-		}
 		addDisposeListener(new DisposeListener() {
 
 			@Override
 			public void widgetDisposed(DisposeEvent e) {
-				fontBold.dispose();
-				choiceMarkerMap.clear();
+				TextCombo.this.choiceMarkerMap.clear();
 			}
 		});
 	}


### PR DESCRIPTION
Long since, when I just wanted to do a small fix for #840 I ended up doing some substantial changes to some custom UI controls, since they typically didn't work well on Linux and probably not on any system where the font differs from Windows default, incl UI scaling.

This PR addresses them as well as some other resource leaks.

**TextCombo layout used on "Script tab"**
Before
![image](https://github.com/eclipse-birt/birt/assets/8941815/72e711ce-7de5-4f45-b073-e83597fb108b)
After
![image](https://github.com/eclipse-birt/birt/assets/8941815/002720d3-88a6-4a1f-860b-9cc60c438d3c)

**Chart style selectors**
Before
![image](https://github.com/eclipse-birt/birt/assets/8941815/9ac44f60-7540-4808-bbd5-17c101ee34f1)
After
![image](https://github.com/eclipse-birt/birt/assets/8941815/c2c5e663-97e9-49b5-a376-e08cb8e41095)

**Font selector**
Before
![image](https://github.com/eclipse-birt/birt/assets/8941815/0f83a3eb-8651-421e-b927-418ac969a96d)
After
![image](https://github.com/eclipse-birt/birt/assets/8941815/a454c314-b9e6-4c4a-8a3c-2e5bf8e59c32)



