### PR TITLE
Enhance of the export viewer dialog to add the excel single sheet option (#645)

### DIFF
--- a/nl/org.eclipse.birt.report.viewer.nl/src/org/eclipse/birt/report/resource/.gitignore
+++ b/nl/org.eclipse.birt.report.viewer.nl/src/org/eclipse/birt/report/resource/.gitignore
@@ -1,6 +1,0 @@
-/Messages_de_DE.properties
-/Messages_es_ES.properties
-/Messages_fr_FR.properties
-/Messages_ja_JP.properties
-/Messages_ko_KR.properties
-/Messages_zh_CN.properties

--- a/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/resource/Messages.properties
+++ b/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/resource/Messages.properties
@@ -118,6 +118,8 @@ birt.viewer.dialog.export.pdf.fittoauto=Auto
 birt.viewer.dialog.export.pdf.fittoactual=Actual size
 birt.viewer.dialog.export.pdf.fittowidth=Fit to page width
 birt.viewer.dialog.export.pdf.fittowhole=Fit to whole page
+birt.viewer.dialog.export.spudsoft.excel.single.sheet=Use single sheet
+
 
 ###############################################################################
 # Print Report dialog 

--- a/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/ajax/ui/dialog/BirtExportReportDialog.js
+++ b/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/ajax/ui/dialog/BirtExportReportDialog.js
@@ -132,7 +132,16 @@ BirtExportReportDialog.prototype = Object.extend( new AbstractBaseDialog( ),
 				}
 				action = action + "&" + Constants.PARAM_PAGERANGE + "=" + pageRange;
 			}			
-			
+
+			// If output format is pdf/ppt/postscript, set some options
+			if( this.__isExcelLayout( format ) )
+			{
+				if( $( 'exportExcelSingleSheetCheckbox' ).checked )
+				{
+					action = action + "&__ExcelEmitter.SingleSheet=true";
+				}
+			}
+
 			// If output format is pdf/ppt/postscript, set some options
 			if( this.__isPDFLayout( format ) )
 			{
@@ -237,8 +246,17 @@ BirtExportReportDialog.prototype = Object.extend( new AbstractBaseDialog( ),
 	 * Enable the extended setting controls according to current selected output format.
 	 */
 	__enableExtSection : function( )
-	{		
+	{
 		var format = $( 'exportFormat' ).value.toLowerCase( );
+
+		if( this.__isExcelLayout( format ) )
+		{
+			this.__setDisplay( 'exportExcelSingleSheet', true);
+		} else
+		{
+			this.__setDisplay( 'exportExcelSingleSheet', false);			
+		}
+		
 		if( this.__isPDFLayout( format ) )
 		{
 			this.__setDisabled( 'exportFitSetting', false );
@@ -268,6 +286,26 @@ BirtExportReportDialog.prototype = Object.extend( new AbstractBaseDialog( ),
 	},
 	
 	/**
+	 * Set the display the control
+	 * 
+	 * @param id, html element
+	 * @param flag, true or false
+	 * @return, void
+	 */
+	__setDisplay: function( id, flag )
+	{
+		var element = $( id );
+		if( element )
+		{
+			if (flag) {
+				element.style.display = "";
+			} else {
+				element.style.display = "none";				
+			}
+		}
+	},
+	
+	/**
 	 * Check whether this format uses the PDF layout
 	 *
 	 * @param format, the output format 
@@ -281,6 +319,27 @@ BirtExportReportDialog.prototype = Object.extend( new AbstractBaseDialog( ),
 		if( format == Constants.FORMAT_PDF 
 		    || format == Constants.FORMAT_POSTSCRIPT
 		    || format == Constants.FORMAT_PPT )
+		{
+			return true;
+		}    
+		
+		return false;
+	},
+
+	/**
+	 * Check whether this format uses the Spudsoft excel layout
+	 *
+	 * @param format, the output format 
+	 * @return true or false
+	 */	 
+	__isExcelLayout : function( format )
+	{
+		if( !format )
+			return false;
+		
+		if( format == Constants.FORMAT_SPUDSOFT_XLS
+		    || format == Constants.FORMAT_SPUDSOFT_XLSX
+		)
 		{
 			return true;
 		}    

--- a/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/ajax/utility/Constants.js
+++ b/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/ajax/utility/Constants.js
@@ -104,6 +104,9 @@ var Constants = {
 	FORMAT_PDF : 'pdf',
 	FORMAT_HTML : 'html',
 	FORMAT_PPT : 'ppt',
+	FORMAT_EXCEL : 'xls',
+	FORMAT_SPUDSOFT_XLS : 'xls_spudsoft',
+	FORMAT_SPUDSOFT_XLSX : 'xlsx',
 	
 	// Action names
 	ACTION_PRINT : 'print',

--- a/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/dialog/ExportReportDialogFragment.jsp
+++ b/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/dialog/ExportReportDialogFragment.jsp
@@ -29,22 +29,34 @@
 	<TR HEIGHT="5px"><TD></TD></TR>
 	<TR>
 		<TD>
-		<label for="exportFormat"><%=BirtResources.getMessage( "birt.viewer.dialog.export.format" )%></label>
-		<SELECT	ID="exportFormat" NAME="format" CLASS="birtviewer_exportreport_dialog_select">
-			<%
-				ParameterAccessor.sortSupportedFormatsByDisplayName(supportedFormats);
-				
-				for ( int i = 0; i < supportedFormats.length; i++ )
-				{
-					if ( !ParameterAccessor.PARAM_FORMAT_HTML.equalsIgnoreCase( supportedFormats[i] ) )
-					{
-			%>
-						<OPTION VALUE="<%= supportedFormats[i] %>"><%= ParameterAccessor.getOutputFormatLabel( supportedFormats[i] ) %></OPTION>
-			<%
-					}
-				}
-			%>
-		</SELECT>
+			<table>
+				<tr>
+					<td>
+						<label for="exportFormat"><%=BirtResources.getMessage( "birt.viewer.dialog.export.format" )%></label>
+						<select	id="exportFormat" name="format" class="birtviewer_exportreport_dialog_select">
+							<%
+								ParameterAccessor.sortSupportedFormatsByDisplayName(supportedFormats);
+								
+								for ( int i = 0; i < supportedFormats.length; i++ )
+								{
+									if ( !ParameterAccessor.PARAM_FORMAT_HTML.equalsIgnoreCase( supportedFormats[i] ) )
+									{
+							%>
+										<OPTION VALUE="<%= supportedFormats[i] %>"><%= ParameterAccessor.getOutputFormatLabel( supportedFormats[i] ) %></OPTION>
+							<%
+									}
+								}
+							%>
+						</select>
+					</td>
+					<td STYLE="padding-left:5px">	
+						<div id="exportExcelSingleSheet">
+							<input type="checkbox" id="exportExcelSingleSheetCheckbox"/>
+							<label id="exportExcelSingleSheetLabel" for="exportExcelSingleSheetCheckbox"><%=BirtResources.getMessage( "birt.viewer.dialog.export.spudsoft.excel.single.sheet" )%></label>
+						</div>
+					</td>
+				</tr>
+			</table>
 		</TD>
 	</TR>
 	<TR HEIGHT="5px"><TD></TD></TR>


### PR DESCRIPTION
This is an enhancement to add the option to create a single sheet output directly with the viewer export based on the Spudsoft option  (#645)

The option will be displayed if the Spudsoft XLS or XLSX is selected.

### XLS
![XLS](https://github.com/eclipse-birt/birt/assets/41593722/5d948ada-b5a1-4608-9094-856e0f3895cb)

### XLSX
![XLSX](https://github.com/eclipse-birt/birt/assets/41593722/e3a92095-d02d-4bd2-b672-b3dccd7bc61c)
