### PR TITLE
Regenerate the target platform after DataTools changes

### DIFF
--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from BIRT" sequenceNumber="25">
+<target name="Generated from BIRT" sequenceNumber="26">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
@@ -148,7 +148,6 @@
       <unit id="javax.xml.rpc" version="0.0.0"/>
       <unit id="javax.xml.soap" version="0.0.0"/>
       <unit id="javax.xml.stream" version="0.0.0"/>
-      <unit id="net.sourceforge.lpg.lpgjavaruntime" version="0.0.0"/>
       <unit id="org.apache.commons.jxpath" version="0.0.0"/>
       <unit id="org.apache.derby" version="0.0.0"/>
       <unit id="org.apache.jasper.glassfish" version="0.0.0"/>
@@ -176,8 +175,6 @@
       <repository location="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/release/latest"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="org.apache.xerces" version="0.0.0"/>
-      <unit id="org.apache.xml.resolver" version="0.0.0"/>
       <unit id="org.eclipse.datatools.common.doc.user.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.datatools.connectivity.doc.user.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.datatools.connectivity.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
This also fixes the strange java.xml.namespace.QName compile error though why that's the case isn't clear.

https://github.com/eclipse-birt/birt/issues/1492