### PR TITLE
Fix the issue with null-reference of uri in SvgFile.isSvg() (#1525)

### DIFF
--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/util/SvgFile.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/util/SvgFile.java
@@ -38,7 +38,7 @@ public class SvgFile {
 	static boolean isSvg = false;
 
 	public static boolean isSvg(String uri) {
-		if (uri != null && uri.endsWith(".svg") || uri.toLowerCase().contains(URL_IMAGE_TYPE_SVG)) {
+		if (uri != null && (uri.endsWith(".svg") || uri.toLowerCase().contains(URL_IMAGE_TYPE_SVG))) {
 			isSvg = true;
 		} else {
 			isSvg = false;


### PR DESCRIPTION
The method isSvg(String) needs additional brackets to avoid a possible NullPointerException.