### PR TITLE
Lock the target platform onto stable update sites

### DIFF
--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/palette/BasePaletteFactory.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/palette/BasePaletteFactory.java
@@ -56,6 +56,7 @@ import org.eclipse.birt.report.model.api.olap.DimensionHandle;
 import org.eclipse.birt.report.model.api.olap.MeasureHandle;
 import org.eclipse.gef.palette.MarqueeToolEntry;
 import org.eclipse.gef.palette.PaletteContainer;
+import org.eclipse.gef.palette.PaletteEntry;
 import org.eclipse.gef.palette.PaletteGroup;
 import org.eclipse.gef.palette.PaletteRoot;
 import org.eclipse.gef.palette.PanningSelectionToolEntry;
@@ -109,7 +110,7 @@ public class BasePaletteFactory {
 	protected static PaletteContainer createControlGroup(PaletteRoot root) {
 		PaletteGroup controlGroup = new PaletteGroup(PALETTE_GROUP_TEXT);
 
-		List<ToolEntry> entries = new ArrayList<>();
+		List<PaletteEntry> entries = new ArrayList<>();
 
 		ToolEntry tool = new PanningSelectionToolEntry(POINTER_SELECT_LABEL, TOOL_TIP_POINTER_SELECT);
 		entries.add(tool);

--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/palette/DesignerPaletteFactory.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/palette/DesignerPaletteFactory.java
@@ -29,6 +29,7 @@ import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Tool;
 import org.eclipse.gef.palette.CombinedTemplateCreationEntry;
 import org.eclipse.gef.palette.PaletteContainer;
+import org.eclipse.gef.palette.PaletteEntry;
 import org.eclipse.gef.palette.PaletteRoot;
 import org.eclipse.gef.requests.CreationFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -197,7 +198,7 @@ public class DesignerPaletteFactory extends BasePaletteFactory {
 	private static PaletteContainer createContentCategory() {
 		PaletteCategory category = new PaletteCategory(IPreferenceConstants.PALETTE_CONTENT, REPORT_ITEMS_LABEL,
 				ReportPlatformUIImages.getImageDescriptor(ISharedImages.IMG_OBJ_FOLDER));
-		List<CombinedTemplateCreationEntry> entries = new ArrayList<>();
+		List<PaletteEntry> entries = new ArrayList<>();
 
 		CombinedTemplateCreationEntry combined = new ReportCombinedTemplateCreationEntry(ELEMENT_NAME_LABEL,
 				TOOL_TIP_LABEL_REPORT_ITEM, IReportElementConstants.REPORT_ELEMENT_LABEL,

--- a/build/org.eclipse.birt.releng/BIRT.setup
+++ b/build/org.eclipse.birt.releng/BIRT.setup
@@ -381,9 +381,28 @@
     <description>The dynamic working sets for  BIRT</description>
   </setupTask>
   <setupTask
+      xsi:type="setup:VariableTask"
+      name="birt.version"
+      value="4.15">
+    <choice
+        value="latest"
+        label="BIRT Latest"/>
+    <choice
+        value="4.15"
+        label="BIRT 4.15"/>
+  </setupTask>
+  <setupTask
+      xsi:type="setup:RedirectionTask"
+      filter="(birt.version=4.15)"
+      sourceURL="https://download.eclipse.org/eclipse/updates/4.31-I-builds"
+      targetURL="https://download.eclipse.org/eclipse/updates/4.31/R-4.31-202402290520">
+    <description>Redirect the I-Build to the release 4.31 release repository for BIRT 4.15</description>
+  </setupTask>
+  <setupTask
       xsi:type="setup.targlets:TargletTask">
     <targlet
-        name="BIRT">
+        name="BIRT"
+        activeRepositoryList="${birt.version}">
       <annotation
           source="http:/www.eclipse.org/oomph/targlets/TargetDefinitionGenerator">
         <detail
@@ -440,7 +459,8 @@
       <sourceLocator
           rootFolder="${git.clone.birt.location}"
           locateNestedProjects="true"/>
-      <repositoryList>
+      <repositoryList
+          name="latest">
         <repository
             url="https://download.eclipse.org/cbi/updates/license"/>
         <repository
@@ -454,13 +474,28 @@
         <repository
             url="https://download.eclipse.org/modeling/emf/emf/builds/milestone/latest"/>
         <repository
-            url="https://download.eclipse.org/tools/gef/classic/releases/latest"/>
+            url="https://download.eclipse.org/tools/gef/classic/milestone/latest"/>
         <repository
             url="https://download.eclipse.org/webtools/repository/latest"/>
         <repository
-            url="https://download.eclipse.org/justj/epp/release/latest"/>
+            url="https://download.eclipse.org/justj/jres/17/updates/release/latest"/>
+      </repositoryList>
+      <repositoryList
+          name="4.15">
+        <repository
+            url="https://download.eclipse.org/cbi/updates/license"/>
+        <repository
+            url="https://download.eclipse.org/releases/2024-03/202403131000"/>
+        <repository
+            url="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.31.0"/>
+        <repository
+            url="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/release/12.0.6"/>
+        <repository
+            url="https://download.eclipse.org/oomph/simrel-orbit-legacy/milestone/latest"/>
         <repository
             url="https://download.eclipse.org/justj/jres/17/updates/release/latest"/>
+        <repository
+            url="https://download.eclipse.org/justj/epp/release/17.0.0.v20240120-1430"/>
       </repositoryList>
     </targlet>
   </setupTask>

--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from BIRT" sequenceNumber="31">
+<target name="Generated from BIRT" sequenceNumber="32">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="bcpg" version="0.0.0"/>
@@ -102,6 +102,7 @@
       <unit id="org.eclipse.jetty.plus" version="0.0.0"/>
       <unit id="org.eclipse.jetty.security" version="0.0.0"/>
       <unit id="org.eclipse.jetty.server" version="0.0.0"/>
+      <unit id="org.eclipse.jetty.servlet" version="0.0.0"/>
       <unit id="org.eclipse.jetty.servlet-api" version="0.0.0"/>
       <unit id="org.eclipse.jetty.session" version="0.0.0"/>
       <unit id="org.eclipse.jetty.util" version="0.0.0"/>
@@ -122,6 +123,7 @@
       <unit id="org.mongodb.mongo-java-driver" version="0.0.0"/>
       <unit id="org.mortbay.jasper.apache-el" version="9.0.83"/>
       <unit id="org.mortbay.jasper.apache-jsp" version="9.0.83"/>
+      <unit id="org.mozilla.javascript" version="0.0.0"/>
       <unit id="org.mozilla.rhino" version="0.0.0"/>
       <unit id="org.objectweb.asm.commons" version="0.0.0"/>
       <unit id="org.osgi.service.coordinator" version="0.0.0"/>
@@ -130,16 +132,13 @@
       <unit id="slf4j.api" version="0.0.0"/>
       <unit id="slf4j.simple" version="0.0.0"/>
       <repository location="https://download.eclipse.org/cbi/updates/license"/>
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest"/>
+      <repository location="https://download.eclipse.org/releases/2024-03/202403131000"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.31.0"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/release/12.0.6"/>
       <repository location="https://download.eclipse.org/oomph/simrel-orbit-legacy/milestone/latest"/>
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/release/latest"/>
-      <repository location="https://download.eclipse.org/datatools/updates/milestone/latest"/>
-      <repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/latest"/>
-      <repository location="https://download.eclipse.org/tools/gef/classic/releases/latest"/>
-      <repository location="https://download.eclipse.org/webtools/repository/latest"/>
-      <repository location="https://download.eclipse.org/justj/epp/release/latest"/>
       <repository location="https://download.eclipse.org/justj/jres/17/updates/release/latest"/>
-      <repository location="https://download.eclipse.org/eclipse/updates/4.31-I-builds"/>
+      <repository location="https://download.eclipse.org/justj/epp/release/17.0.0.v20240120-1430"/>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.31/R-4.31-202402290520"/>
     </location>
   </locations>
 </target>


### PR DESCRIPTION
Update the setup for generating this target platform, but also easily configured to switch back to on-going development versions.

Fix compile problems compiling against the latest GEF release.

https://github.com/eclipse-birt/birt/issues/1572