### PR TITLE
Avoid BIRT binary equivalents in the target platform

### DIFF
--- a/build/org.eclipse.birt.releng/BIRT.setup
+++ b/build/org.eclipse.birt.releng/BIRT.setup
@@ -402,7 +402,8 @@
       xsi:type="setup.targlets:TargletTask">
     <targlet
         name="BIRT"
-        activeRepositoryList="${birt.version}">
+        activeRepositoryList="${birt.version}"
+        includeBinaryEquivalents="false">
       <annotation
           source="http:/www.eclipse.org/oomph/targlets/TargetDefinitionGenerator">
         <detail

--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from BIRT" sequenceNumber="32">
+<target name="Generated from BIRT" sequenceNumber="33">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="bcpg" version="0.0.0"/>
@@ -123,7 +123,6 @@
       <unit id="org.mongodb.mongo-java-driver" version="0.0.0"/>
       <unit id="org.mortbay.jasper.apache-el" version="9.0.83"/>
       <unit id="org.mortbay.jasper.apache-jsp" version="9.0.83"/>
-      <unit id="org.mozilla.javascript" version="0.0.0"/>
       <unit id="org.mozilla.rhino" version="0.0.0"/>
       <unit id="org.objectweb.asm.commons" version="0.0.0"/>
       <unit id="org.osgi.service.coordinator" version="0.0.0"/>


### PR DESCRIPTION
This is relevant when using the release train in the target platform during resolution/generation because the train includes some much older versions of BIRT.

https://github.com/eclipse-birt/birt/pull/1585