### PR TITLE
ReportPreviewFormPage needs StaticHTMLViewer

### DIFF
--- a/UI/org.eclipse.birt.report.designer.ui.rcp/BIRT-headless.product
+++ b/UI/org.eclipse.birt.report.designer.ui.rcp/BIRT-headless.product
@@ -259,6 +259,7 @@ United States, other countries, or both.
       <plugin id="org.eclipse.birt.report.designer.ui.editors.schematic"/>
       <plugin id="org.eclipse.birt.report.designer.ui.lib"/>
       <plugin id="org.eclipse.birt.report.designer.ui.lib.explorer"/>
+      <plugin id="org.eclipse.birt.report.designer.ui.preview.static_html"/>
       <plugin id="org.eclipse.birt.report.designer.ui.preview.web"/>
       <plugin id="org.eclipse.birt.report.designer.ui.rcp"/>
       <plugin id="org.eclipse.birt.report.designer.ui.samples.rcp"/>

--- a/UI/org.eclipse.birt.report.designer.ui.rcp/BIRT.product
+++ b/UI/org.eclipse.birt.report.designer.ui.rcp/BIRT.product
@@ -259,6 +259,7 @@ United States, other countries, or both.
       <plugin id="org.eclipse.birt.report.designer.ui.editors.schematic"/>
       <plugin id="org.eclipse.birt.report.designer.ui.lib"/>
       <plugin id="org.eclipse.birt.report.designer.ui.lib.explorer"/>
+      <plugin id="org.eclipse.birt.report.designer.ui.preview.static_html"/>
       <plugin id="org.eclipse.birt.report.designer.ui.preview.web"/>
       <plugin id="org.eclipse.birt.report.designer.ui.rcp"/>
       <plugin id="org.eclipse.birt.report.designer.ui.samples.rcp"/>

--- a/features/org.eclipse.birt.feature/feature.xml
+++ b/features/org.eclipse.birt.feature/feature.xml
@@ -335,6 +335,13 @@
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.birt.report.designer.ui.preview.static_html"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.birt.report.designer.ui.preview.web"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
The preview tab cannot work without the contribution from bundle org.eclipse.birt.report.designer.ui.preview.static_html so that bundle should be included in features and products that include org.eclipse.birt.report.designer.ui.preview.

https://github.com/eclipse-birt/birt/issues/1589