### PR TITLE
Fix the issue with spaces into the designer path on "viewer web server" side (part 02, #1621)

### DIFF
--- a/viewer/org.eclipse.birt.report.viewer/src/org/eclipse/birt/report/viewer/utilities/ViewerWebServer.java
+++ b/viewer/org.eclipse.birt.report.viewer/src/org/eclipse/birt/report/viewer/utilities/ViewerWebServer.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import org.eclipse.birt.report.viewer.ViewerPlugin;
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
@@ -93,17 +94,17 @@ public class ViewerWebServer {
 
 		for (String xmlFile : configFiles) {
 			URL url = bundle.getEntry(jettyBase + xmlFile);
-			URL fileURL = FileLocator.toFileURL(url);
+			URL fileURL = URIUtil.toURI(FileLocator.toFileURL(url)).toURL();
 			if (fileURL != null) {
 				resolvedXmlPaths.add(fileURL);
 			}
 		}
 
 		URL jettyHomeUrl = bundle.getEntry(JETTY_FOLDER_NAME + "/" + JETTY_HOME_FOLDER_NAME);
-		URL jettyHomeFileUrl = FileLocator.toFileURL(jettyHomeUrl);
+		URL jettyHomeFileUrl = URIUtil.toURI(FileLocator.toFileURL(jettyHomeUrl)).toURL();
 
 		URL jettyBaseUrl = bundle.getEntry(JETTY_FOLDER_NAME + "/" + JETTY_BASE_FOLDER_NAME);
-		URL jettyBaseFileUrl = FileLocator.toFileURL(jettyBaseUrl);
+		URL jettyBaseFileUrl = URIUtil.toURI(FileLocator.toFileURL(jettyBaseUrl)).toURL();
 
 		// Lets load our properties
 		Map<String, String> properties = new HashMap<>();


### PR DESCRIPTION
Fix the issue with spaces into the designer path on "viewer web server" side (part 02, #1621)

- PR #1621 solved the issue on "ViewerWebApp.start()"

The current nightly build shows that now an additional issue is on "ViewerWebServer" with the same problem
and this PR should solve the issue.

Error message:
![ViewerWebServer-start](https://github.com/eclipse-birt/birt/assets/41593722/b7c65c3f-4511-4e44-8126-5a5dad5e9d81)



