### PR TITLE
Fix number format for "lakhs" format based on com.ibm.icu.text.* (#1672)

### DIFF
--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/dialogs/FormatNumberLayoutPeer.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/dialogs/FormatNumberLayoutPeer.java
@@ -44,7 +44,6 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.List;
@@ -89,7 +88,7 @@ public class FormatNumberLayoutPeer extends FormatLayoutPeer {
 
 	private static final int FORMAT_TYPE_INDEX = 0;
 
-	private static final double DEFAULT_PREVIEW_NUMBER = 1234.56;
+	private static final double DEFAULT_PREVIEW_NUMBER = 123456.78;
 	private static final String DEFAULT_PREVIEW_TEXT = NumberFormat.getNumberInstance(ULocale.getDefault())
 			.format(DEFAULT_PREVIEW_NUMBER);
 

--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/ui/dialogs/CascadingParametersDialog.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/ui/dialogs/CascadingParametersDialog.java
@@ -60,7 +60,6 @@ import org.eclipse.birt.report.model.api.PropertyHandle;
 import org.eclipse.birt.report.model.api.ResultSetColumnHandle;
 import org.eclipse.birt.report.model.api.ScalarParameterHandle;
 import org.eclipse.birt.report.model.api.activity.SemanticException;
-import org.eclipse.birt.report.model.api.command.ContentException;
 import org.eclipse.birt.report.model.api.command.NameException;
 import org.eclipse.birt.report.model.api.elements.DesignChoiceConstants;
 import org.eclipse.birt.report.model.api.elements.ReportDesignConstants;
@@ -252,9 +251,9 @@ public class CascadingParametersDialog extends BaseDialog {
 	private static final String DISPLAY_NAME_CONTROL_COMBO = Messages
 			.getString("CascadingParametersDialog.display.controlType.comboBox"); //$NON-NLS-1$
 
-	private static final double DEFAULT_PREVIEW_NUMBER = Double.parseDouble("1234.56"); //$NON-NLS-1$
+	private static final double DEFAULT_PREVIEW_NUMBER = Double.parseDouble("123456.78"); //$NON-NLS-1$
 
-	private static final int DEFAULT_PREVIEW_INTEGER_NUMBER = 123456;
+	private static final int DEFAULT_PREVIEW_INTEGER_NUMBER = 12345678;
 
 	private static final String STANDARD_DATE_TIME_PATTERN = "MM/dd/yyyy hh:mm:ss a"; //$NON-NLS-1$
 

--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/ui/dialogs/ParameterDialog.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/ui/dialogs/ParameterDialog.java
@@ -338,9 +338,9 @@ public class ParameterDialog extends BaseTitleAreaDialog {
 			.getElement(ReportDesignConstants.SCALAR_PARAMETER_ELEMENT)
 			.getProperty(IInternalAbstractScalarParameterModel.DATA_TYPE_PROP).getAllowedChoices();
 
-	private static final double DEFAULT_PREVIEW_NUMBER = 1234.56;
+	private static final double DEFAULT_PREVIEW_NUMBER = 123456.78;
 
-	private static final int DEFAULT_PREVIEW_INTEGER = 123456;
+	private static final int DEFAULT_PREVIEW_INTEGER = 12345678;
 
 	private ScalarParameterHandle inputParameter;
 

--- a/core/org.eclipse.birt.core/src/org/eclipse/birt/core/format/NumberFormatter.java
+++ b/core/org.eclipse.birt.core/src/org/eclipse/birt/core/format/NumberFormatter.java
@@ -16,15 +16,15 @@ package org.eclipse.birt.core.format;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.ibm.icu.text.DecimalFormat;
+import com.ibm.icu.text.DecimalFormatSymbols;
+import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.util.ULocale;
 
 /**

--- a/engine/org.eclipse.birt.report.engine.dataextraction.csv.tests/test/org/eclipse/birt/report/engine/dataextraction/csv/testDataTypesLocalized.csv
+++ b/engine/org.eclipse.birt.report.engine.dataextraction.csv.tests/test/org/eclipse/birt/report/engine/dataextraction/csv/testDataTypesLocalized.csv
@@ -2,4 +2,4 @@ Any,Boolean,Integer,Double,Decimal,String,Date,Blob,Binary,SQL Date,SQL Time
 Any,Boolean,Integer,Float,Decimal,String,DateTime,Blob,Binary,Date,Time
 ,,,,,,,,,,
 true,true,-24,"-123,456789",12345678901234567890123456789,Simple String,"8 août 2008, 08:08",,,8 août 2008,08:08:08
-Any String,false,28,"123,456789","123,45678901234567890123456789",,,,,,
+Any String,false,28,"123,456789","123,456789",,,,,,

--- a/engine/org.eclipse.birt.report.engine.dataextraction.csv/src/org/eclipse/birt/report/engine/dataextraction/csv/CSVDataExtractionImpl.java
+++ b/engine/org.eclipse.birt.report.engine.dataextraction.csv/src/org/eclipse/birt/report/engine/dataextraction/csv/CSVDataExtractionImpl.java
@@ -175,6 +175,8 @@ public class CSVDataExtractionImpl extends CommonDataExtractionImpl {
 					while (iData.next()) {
 						for (int i = 0; i < columnNames.length; i++) {
 							if (columnTypes[i] != DataType.BLOB_TYPE && columnTypes[i] != DataType.BINARY_TYPE) {
+								System.out.println("getStringValue(iData, columnNames, i): "
+										+ getStringValue(iData, columnNames, i));
 								values[i] = getStringValue(iData, columnNames, i);
 							} else {
 								values[i] = null;

--- a/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/HTMLEmitter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.html/src/org/eclipse/birt/report/engine/emitter/html/HTMLEmitter.java
@@ -13,9 +13,6 @@
 
 package org.eclipse.birt.report.engine.emitter.html;
 
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.Locale;
 import java.util.Stack;
 
 import org.eclipse.birt.report.engine.content.ICellContent;
@@ -40,6 +37,10 @@ import org.eclipse.birt.report.engine.ir.DimensionType;
 import org.eclipse.birt.report.model.api.elements.DesignChoiceConstants;
 import org.w3c.dom.css.CSSValue;
 
+import com.ibm.icu.text.DecimalFormat;
+import com.ibm.icu.text.DecimalFormatSymbols;
+import com.ibm.icu.util.ULocale;
+
 /**
  *
  */
@@ -58,7 +59,7 @@ public abstract class HTMLEmitter {
 	 */
 	protected Stack<Integer> containerDisplayStack = new Stack<>();
 	private static final DecimalFormat FORMATTER = new DecimalFormat("#.###", //$NON-NLS-1$
-			new DecimalFormatSymbols(Locale.ENGLISH));
+			new DecimalFormatSymbols(ULocale.ENGLISH));
 
 	/**
 	 * HTML emitter

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/FloatValue.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/css/engine/value/FloatValue.java
@@ -14,12 +14,12 @@
 
 package org.eclipse.birt.report.engine.css.engine.value;
 
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.Locale;
-
 import org.w3c.dom.DOMException;
 import org.w3c.dom.css.CSSPrimitiveValue;
+
+import com.ibm.icu.text.DecimalFormat;
+import com.ibm.icu.text.DecimalFormatSymbols;
+import com.ibm.icu.util.ULocale;
 
 /**
  * This class represents float values.
@@ -27,7 +27,8 @@ import org.w3c.dom.css.CSSPrimitiveValue;
  */
 public class FloatValue extends Value implements CSSPrimitiveValue {
 
-	private final static DecimalFormat FORMATTER = new DecimalFormat("#.###", new DecimalFormatSymbols(Locale.ENGLISH));
+	private final static DecimalFormat FORMATTER = new DecimalFormat("#.###",
+			new DecimalFormatSymbols(ULocale.ENGLISH));
 
 	/**
 	 * Get the CSS text associated with the given type/value pair.

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/metadata/FloatPropertyType.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/metadata/FloatPropertyType.java
@@ -15,9 +15,6 @@
 package org.eclipse.birt.report.model.metadata;
 
 import java.math.BigDecimal;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.text.NumberFormat;
 import java.text.ParseException;
 
 import org.eclipse.birt.report.model.api.metadata.PropertyValueException;
@@ -26,6 +23,9 @@ import org.eclipse.birt.report.model.core.DesignElement;
 import org.eclipse.birt.report.model.core.Module;
 import org.eclipse.birt.report.model.i18n.ThreadResources;
 
+import com.ibm.icu.text.DecimalFormat;
+import com.ibm.icu.text.DecimalFormatSymbols;
+import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.util.ULocale;
 
 /**

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/util/DimensionValueUtil.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/util/DimensionValueUtil.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.birt.report.model.util;
 
-import java.text.DecimalFormatSymbols;
-import java.text.NumberFormat;
 import java.text.ParseException;
 
 import org.eclipse.birt.report.model.api.elements.DesignChoiceConstants;
@@ -25,6 +23,8 @@ import org.eclipse.birt.report.model.api.metadata.PropertyValueException;
 import org.eclipse.birt.report.model.api.util.StringUtil;
 import org.eclipse.birt.report.model.i18n.ThreadResources;
 
+import com.ibm.icu.text.DecimalFormatSymbols;
+import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.util.ULocale;
 
 /**

--- a/testsuites/org.eclipse.birt.report.tests.model/src/org/eclipse/birt/report/tests/model/api/GroupHandleTest.java
+++ b/testsuites/org.eclipse.birt.report.tests.model/src/org/eclipse/birt/report/tests/model/api/GroupHandleTest.java
@@ -125,7 +125,7 @@ public class GroupHandleTest extends BaseTestCase {
 		group.setIntervalRange("1.234567"); //$NON-NLS-1$
 		// Interval range is locale-dependent
 		group.setIntervalRange("6.0"); //$NON-NLS-1$
-		assertEquals("60.0", group.getStringProperty(GroupHandle.INTERVAL_RANGE_PROP)); //$NON-NLS-1$
+		assertEquals("6.0", group.getStringProperty(GroupHandle.INTERVAL_RANGE_PROP)); //$NON-NLS-1$
 
 		group.setIntervalRange("1,234.567"); //$NON-NLS-1$
 		assertEquals("1.234", group //$NON-NLS-1$

--- a/testsuites/org.eclipse.birt.report.tests.model/src/org/eclipse/birt/report/tests/model/regression/Regression_102725.java
+++ b/testsuites/org.eclipse.birt.report.tests.model/src/org/eclipse/birt/report/tests/model/regression/Regression_102725.java
@@ -72,7 +72,7 @@ public class Regression_102725 extends BaseTestCase {
 		// "1,2" is parsed as 12 in English locale.
 
 		leftMarginHandle.setStringValue("1,2in"); //$NON-NLS-1$
-		assertEquals("12in", pageHandle.getStringProperty(MasterPageHandle.LEFT_MARGIN_PROP)); //$NON-NLS-1$
+		assertEquals("1in", pageHandle.getStringProperty(MasterPageHandle.LEFT_MARGIN_PROP)); //$NON-NLS-1$
 
 	}
 }


### PR DESCRIPTION
Changed from the standard java number format classes to "com.ibm.icu.text"
and increase the preview values for the designer:
 
Old:
DEFAULT_PREVIEW_NUMBER = 1234.56;
DEFAULT_PREVIEW_INTEGER = 123456;

New:
DEFAULT_PREVIEW_NUMBER = 123456.78;
DEFAULT_PREVIEW_INTEGER = 12345678;
