### PR TITLE
Out of memory error when creating a chart #1727

### DIFF
--- a/build/birt-packages/birt-report-all-in-one/BIRT.product
+++ b/build/birt-packages/birt-report-all-in-one/BIRT.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="BIRT Report Designer All-In-One" uid="org.eclipse.birt.report.designer.all" id="org.eclipse.birt.branding.birt_all_in_one" application="org.eclipse.ui.ide.workbench" version="4.16.0.qualifier" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="BIRT Report Designer All-In-One" uid="org.eclipse.birt.report.designer.all" id="org.eclipse.birt.branding.birt_all_in_one" application="org.eclipse.ui.ide.workbench" version="4.16.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.birt.branding/images/about.png"/>
@@ -38,7 +38,7 @@ Powered by the Eclipse Platform: https://eclipse.org/eclipse
 -product org.eclipse.birt.branding.birt_all_in_one
       </programArgs>
       <vmArgs>-Xms512m
--Xmx1024m
+-Xmx2048m
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>

--- a/chart/org.eclipse.birt.chart.ui/src/org/eclipse/birt/chart/ui/util/ChartUIUtil.java
+++ b/chart/org.eclipse.birt.chart.ui/src/org/eclipse/birt/chart/ui/util/ChartUIUtil.java
@@ -206,7 +206,7 @@ public class ChartUIUtil {
 	 * @return the default number format
 	 */
 	public static NumberFormat getDefaultNumberFormatInstance() {
-		NumberFormat numberFormat = NumberFormat.getInstance();
+		NumberFormat numberFormat = NumberFormat.getInstance(ULocale.getDefault());
 		// fix icu limitation which only allow 3 fraction digits as maximum by
 		// default. ?100 is enough.
 		numberFormat.setMaximumFractionDigits(100);


### PR DESCRIPTION
1. Sometimes NumberFormat is used to handle the decimal point
and in other cases there is a dependency on ULocale.

A small fix was made to use the default ULocale in the
Numberformat calculations instead of the default NumberFormat

The whole operation is not fully understood so more issues
could arise.

2. To avoid memory cramps, an additional 1GB was added to the
maximum memory.

See the issue for a discussion.