### PR TITLE
Enhance the image scaling of excel and keep the size of small images (#1752)

### DIFF
--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/ExcelEmitter.java
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/ExcelEmitter.java
@@ -79,6 +79,9 @@ public abstract class ExcelEmitter implements IContentEmitter {
 	/** property: ExcelEmitter.SingleSheetWithPageBreaks */
 	public static final String SINGLE_SHEET_PAGE_BREAKS = "ExcelEmitter.SingleSheetWithPageBreaks";
 
+	/** property: ExcelEmitter.ImageScalingToCellDimension */
+	public static final String IMAGE_SCALING_CELL_DIMENSION = "ExcelEmitter.ImageScalingToCellDimension";
+
 	/** property: ExcelEmitter.InsertPrintBreakAfter */
 	public static final String PRINT_BREAK_AFTER = "ExcelEmitter.InsertPrintBreakAfter";
 

--- a/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/README.md
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/src/uk/co/spudsoft/birt/emitters/excel/README.md
@@ -341,3 +341,14 @@ The following list get an overview of all supported user properties, the content
 	           	SpacingAll, indent calculated based on cell padding & element padding & margin
 	Default    	SpacingAll
 	Since      	4.16
+
+**ExcelEmitter.ImageScalingToCellDimension**
+
+	Content    	scaling of all images to the cell dimension
+	Location   	report
+	Data type  	boolean
+	Values    	true, all images will be scaled to the cell dimension
+				 	false, only the images with larger dimensions like the content cell will be scaled
+				 	and the small images keep the original image size
+	Default    	false
+	Since      	4.17


### PR DESCRIPTION
The image scaling is enhanced to keep the original image size of small images without scaling to cell dimension 