### PR TITLE
Reduce org.eclipse.birt.engine.runtime content

### DIFF
--- a/build/birt-packages/birt-runtime-osgi/reportengine.product
+++ b/build/birt-packages/birt-runtime-osgi/reportengine.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="BIRT Engine Runtime" uid="org.eclipse.birt.engine.runtime" version="4.17.0.qualifier" type="features" includeLaunchers="false" autoIncludeRequirements="true">
+<product name="BIRT Engine Runtime" uid="org.eclipse.birt.engine.runtime" version="4.17.0.qualifier" type="mixed" includeLaunchers="false" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>
@@ -165,12 +165,16 @@ United States, other countries, or both.
    </license>
 
    <plugins>
+      <plugin id="org.apache.felix.scr"/>
+      <plugin id="org.eclipse.core.runtime"/>
+      <plugin id="org.eclipse.equinox.common"/>
+      <plugin id="org.eclipse.equinox.event"/>
+      <plugin id="org.eclipse.equinox.simpleconfigurator"/>
    </plugins>
 
    <features>
       <feature id="org.eclipse.birt.engine.runtime"/>
       <feature id="org.eclipse.birt.chart.osgi.runtime"/>
-      <feature id="org.eclipse.rcp" installMode="root"/>
    </features>
 
    <configurations>
@@ -178,9 +182,6 @@ United States, other countries, or both.
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
-      <!--
-      <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="0" />
-      -->
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
       <property name="org.eclipse.update.reconcile" value="false" />
    </configurations>

--- a/features/org.eclipse.birt.chart.osgi.runtime/feature.xml
+++ b/features/org.eclipse.birt.chart.osgi.runtime/feature.xml
@@ -67,18 +67,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.birt.chart.ui.extension"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.birt.chart.ui"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.birt.core.ui"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.birt.core"
          version="0.0.0"/>
 

--- a/viewer/org.eclipse.birt.report.viewer/META-INF/MANIFEST.MF
+++ b/viewer/org.eclipse.birt.report.viewer/META-INF/MANIFEST.MF
@@ -27,7 +27,6 @@ Export-Package: org.eclipse.birt.report.filter,
  org.eclipse.birt.report.viewer.browsers.system,
  org.eclipse.birt.report.viewer.utilities
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
- org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",
  org.apache.axis;bundle-version="[1.3.0,2.0.0)",
  org.eclipse.equinox.jsp.jasper.registry;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.equinox.http.registry;bundle-version="[1.0.0,2.0.0)",


### PR DESCRIPTION
- Remove org.eclipse.rcp to eliminate UI dependencies.
- Add a minimized set of additional plugins.
- Remove UI bundles from the org.eclipse.birt.chart.osgi.runtime feature.
- Remove org.eclipse.core.resources from org.eclipse.birt.report.viewer.