### PR TITLE
Remove UI dependencies from org.eclipse.birt.osgi.runtime

### DIFF
--- a/chart/org.eclipse.birt.chart.tests/pom.xml
+++ b/chart/org.eclipse.birt.chart.tests/pom.xml
@@ -35,22 +35,6 @@
 					<argLine>-Duser.country=us -Duser.language=en</argLine>
 				</configuration>
 			</plugin>
-            <plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>target-platform-configuration</artifactId>
-				<version>${tycho.version}</version>
-				<configuration>
-					<dependency-resolution>
-						<extraRequirements>
-							<requirement>
-								<type>eclipse-feature</type>
-								<id>org.eclipse.birt</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
-						</extraRequirements>
-					</dependency-resolution>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/org.eclipse.birt.core.testhelper/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.birt.core.testhelper/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.birt.core.testhelper
 Bundle-Version: 4.17.0.qualifier
 Fragment-Host: org.eclipse.birt.core;bundle-version="2.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit;bundle-version="4.7.0";resolution:=optional;visibility:=reexport
+Require-Bundle: org.junit
 Bundle-ClassPath: .
 Export-Package: org.eclipse.birt.core.archive.compound,
  org.eclipse.birt.core.archive.cache

--- a/core/org.eclipse.birt.core.tests/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.birt.core.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,9 @@ Bundle-Activator: org.eclipse.birt.core.Activator
 Import-Package: org.osgi.framework;version="1.3.0"
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.birt.core;bundle-version="4.13.0",
- org.junit;bundle-version="4.13.0";resolution:=optional;visibility:=reexport
+ org.junit;bundle-version="4.13.0";resolution:=optional;visibility:=reexport,
+ org.eclipse.birt.core.script.function;bundle-version="4.17.0",
+ org.eclipse.birt.report.engine.script.javascript;bundle-version="4.17.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %Bundle-Vendor
 Automatic-Module-Name: org.eclipse.birt.core.tests

--- a/core/org.eclipse.birt.core.tests/pom.xml
+++ b/core/org.eclipse.birt.core.tests/pom.xml
@@ -37,16 +37,6 @@
 								<id>org.eclipse.birt.core.testhelper</id>
 								<versionRange>0.0.0</versionRange>
 							</requirement>
-							<requirement>
-								<type>eclipse-plugin</type>
-								<id>org.eclipse.birt.core.script.function</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
-							<requirement>
-								<type>eclipse-plugin</type>
-								<id>org.eclipse.birt.report.engine.script.javascript</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
 						</extraRequirements>
 					</dependency-resolution>
 				</configuration>

--- a/data/org.eclipse.birt.report.data.adapter/META-INF/MANIFEST.MF
+++ b/data/org.eclipse.birt.report.data.adapter/META-INF/MANIFEST.MF
@@ -7,8 +7,7 @@ Bundle-Activator: org.eclipse.birt.report.data.adapter.Activator
 Require-Bundle: org.eclipse.birt.core;bundle-version="[2.1.0,5.0.0)",
  org.eclipse.birt.data;bundle-version="[2.1.0,5.0.0)",
  org.eclipse.birt.report.model;bundle-version="[2.1.0,5.0.0)",
- org.eclipse.birt.data.aggregation;bundle-version="[1.0.0,5.0.0)",
- org.junit;bundle-version="[4.8.1,5.0.0)";resolution:=optional
+ org.eclipse.birt.data.aggregation;bundle-version="[1.0.0,5.0.0)"
 Bundle-ActivationPolicy: lazy
 Eclipse-ExtensibleAPI: true
 Export-Package: org.eclipse.birt.report.data.adapter,

--- a/data/org.eclipse.birt.report.data.oda.xml/META-INF/MANIFEST.MF
+++ b/data/org.eclipse.birt.report.data.oda.xml/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-ClassPath: .
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.datatools.connectivity.oda;bundle-version="[3.0.1,4.0.0)",
- org.junit;bundle-version="3.8.1";resolution:=optional,
  org.eclipse.datatools.enablement.oda.xml;bundle-version="[1.0.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.birt.report.data.oda.xml; x-internal:=false,

--- a/engine/org.eclipse.birt.report.engine.dataextraction.csv.tests/META-INF/MANIFEST.MF
+++ b/engine/org.eclipse.birt.report.engine.dataextraction.csv.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.birt.report.engine.dataextraction.csv.tests
 Bundle-Version: 4.17.0.qualifier
 Fragment-Host: org.eclipse.birt.report.engine.dataextraction.csv
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit;bundle-version="4.13.0";resolution:=optional;visibility:=reexport
+Require-Bundle: org.junit
 Export-Package: org.eclipse.birt.report.engine.dataextraction.csv,
  org.eclipse.birt.report.engine.dataextraction.csv.mock
 Import-Package: org.eclipse.birt.data.engine.api

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/pom.xml
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/pom.xml
@@ -23,24 +23,4 @@
 	</parent>
 	<artifactId>org.eclipse.birt.report.engine.emitter.pdf.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-<!--	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>target-platform-configuration</artifactId>
-				<version>${tycho.version}</version>
-				<configuration>
-					<dependency-resolution>
-						<extraRequirements>
-							<requirement>
-								<type>eclipse-feature</type>
-								<id>org.eclipse.birt.osgi.runtime</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
-						</extraRequirements>
-					</dependency-resolution>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build> -->
 </project>

--- a/engine/org.eclipse.birt.report.engine.emitter.postscript.tests/META-INF/MANIFEST.MF
+++ b/engine/org.eclipse.birt.report.engine.emitter.postscript.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Import-Package: org.osgi.framework;version="1.3.0"
 Require-Bundle: org.eclipse.birt.core;bundle-version="4.13.0",
  org.eclipse.birt.report.engine;bundle-version="4.13.0",
  org.eclipse.birt.report.engine.emitter.postscript;bundle-version="4.13.0",
- org.junit;bundle-version="4.7.0";resolution:=optional;visibility:=reexport
+ org.junit
 Bundle-Vendor: %Bundle-Vendor
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/engine/uk.co.spudsoft.birt.emitters.excel.tests/pom.xml
+++ b/engine/uk.co.spudsoft.birt.emitters.excel.tests/pom.xml
@@ -23,24 +23,4 @@
 	</parent>
 	<artifactId>uk.co.spudsoft.birt.emitters.excel.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-<!--	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>target-platform-configuration</artifactId>
-				<version>${tycho.version}</version>
-				<configuration>
-					<dependency-resolution>
-						<extraRequirements>
-							<requirement>
-								<type>eclipse-feature</type>
-								<id>org.eclipse.birt.osgi.runtime</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
-						</extraRequirements>
-					</dependency-resolution>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build> -->
 </project>

--- a/features/org.eclipse.birt.osgi.runtime/feature.xml
+++ b/features/org.eclipse.birt.osgi.runtime/feature.xml
@@ -87,10 +87,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.birt.report.viewer"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.birt.report.engine.dataextraction"
          version="0.0.0"/>
 
@@ -120,10 +116,6 @@
 
    <plugin
          id="org.eclipse.birt.data.oda.mongodb"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.birt.data.oda.mongodb.ui"
          version="0.0.0"/>
 
    <plugin

--- a/model/org.eclipse.birt.report.model.adapter.oda.tests/META-INF/MANIFEST.MF
+++ b/model/org.eclipse.birt.report.model.adapter.oda.tests/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Require-Bundle: org.eclipse.birt.core;bundle-version="4.13.0",
  org.eclipse.birt.report.model.adapter.oda;bundle-version="4.13.0",
  org.eclipse.birt.report.model;bundle-version="4.13.0",
  org.eclipse.datatools.connectivity.oda.design;bundle-version="3.5.101",
- org.junit;bundle-version="4.8.1";resolution:=optional;visibility:=reexport
+ org.junit
 Bundle-Vendor: %Bundle-Vendor
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/model/org.eclipse.birt.report.model.tests/pom.xml
+++ b/model/org.eclipse.birt.report.model.tests/pom.xml
@@ -47,11 +47,6 @@
 								<id>org.eclipse.birt.report.modelextension.tests</id>
 								<versionRange>0.0.0</versionRange>
 							</requirement>
-							<requirement>
-								<type>eclipse-feature</type>
-								<id>org.eclipse.birt.osgi.runtime</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
 						</extraRequirements>
 					</dependency-resolution>
 				</configuration>

--- a/testsuites/org.eclipse.birt.report.tests.chart/META-INF/MANIFEST.MF
+++ b/testsuites/org.eclipse.birt.report.tests.chart/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-ClassPath: .
 Bundle-Version: 4.17.0.qualifier
 Bundle-Activator: org.eclipse.birt.report.tests.chart.plugin.ChartPlugin
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.junit;resolution:=optional,
+Require-Bundle: org.junit,
  org.eclipse.birt.chart.device.extension,
  org.eclipse.birt.chart.device.svg,
  org.eclipse.birt.chart.engine,

--- a/testsuites/org.eclipse.birt.report.tests.chart/pom.xml
+++ b/testsuites/org.eclipse.birt.report.tests.chart/pom.xml
@@ -30,22 +30,6 @@
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>target-platform-configuration</artifactId>
-				<version>${tycho.version}</version>
-				<configuration>
-					<dependency-resolution>
-						<extraRequirements>
-							<requirement>
-								<type>eclipse-feature</type>
-								<id>org.eclipse.birt.osgi.runtime</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
-						</extraRequirements>
-					</dependency-resolution>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>

--- a/testsuites/org.eclipse.birt.report.tests.engine/META-INF/MANIFEST.MF
+++ b/testsuites/org.eclipse.birt.report.tests.engine/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-ClassPath: .
 Bundle-Version: 4.17.0.qualifier
 Bundle-Activator: org.eclipse.birt.report.tests.engine.plugin.EnginePlugin
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.junit;bundle-version="4.13.0";resolution:=optional,
+Require-Bundle: org.junit,
  org.eclipse.birt.core;bundle-version="4.13.0",
  org.eclipse.birt.tests.core;bundle-version="4.13.0",
  org.eclipse.birt.chart.engine;bundle-version="4.13.0",

--- a/testsuites/org.eclipse.birt.report.tests.model/META-INF/MANIFEST.MF
+++ b/testsuites/org.eclipse.birt.report.tests.model/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 4.17.0.qualifier
 Bundle-Activator: org.eclipse.birt.report.tests.model.plugin.ModelPlugin
 Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.junit;bundle-version="4.13.0";resolution:=optional,
+Require-Bundle: org.junit,
  org.eclipse.birt.report.model;bundle-version="4.13.0",
  org.eclipse.birt.core;bundle-version="4.13.0",
  org.eclipse.birt.tests.core;bundle-version="4.13.0",

--- a/testsuites/org.eclipse.birt.tests.data/META-INF/MANIFEST.MF
+++ b/testsuites/org.eclipse.birt.tests.data/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.birt.tests.data;singleton:=true
 Bundle-ClassPath: .
 Bundle-Version: 4.17.0.qualifier
 Bundle-Activator: org.eclipse.birt.tests.data.engine.plugin.DataPlugin
-Require-Bundle: org.junit;bundle-version="4.13.0";resolution:=optional,
+Require-Bundle: org.junit,
  org.eclipse.birt.core;bundle-version="4.13.0",
  org.eclipse.datatools.connectivity.oda;bundle-version="3.6.101",
  org.eclipse.datatools.connectivity.oda.flatfile;bundle-version="3.3.101",

--- a/viewer/org.eclipse.birt.report.viewer.tests/META-INF/MANIFEST.MF
+++ b/viewer/org.eclipse.birt.report.viewer.tests/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 4.17.0.qualifier
 Fragment-Host: org.eclipse.birt.report.viewer;bundle-version="2.3.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.birt.report.viewer
-Require-Bundle: org.junit;bundle-version="3.8.1";resolution:=optional;visibility:=reexport,
+Require-Bundle: org.junit,
  javax.servlet-api;bundle-version="3.1.0"
 Bundle-Vendor: %Bundle-Vendor
 Automatic-Module-Name: org.eclipse.birt.report.viewer.tests

--- a/xtab/org.eclipse.birt.report.item.crosstab.core.tests/META-INF/MANIFEST.MF
+++ b/xtab/org.eclipse.birt.report.item.crosstab.core.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,8 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.birt.report.item.crosstab.core.tests;singleton:=true
 Bundle-Version: 4.17.0.qualifier
 Fragment-Host: org.eclipse.birt.report.item.crosstab.core;bundle-version="1.0.0"
-Require-Bundle: org.junit;bundle-version="4.13.0"
+Require-Bundle: org.junit;bundle-version="4.13.0",
+ org.eclipse.birt.report.modelextension.tests;bundle-version="4.17.0"
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.birt.report.item.crosstab.core.tests

--- a/xtab/org.eclipse.birt.report.item.crosstab.core.tests/pom.xml
+++ b/xtab/org.eclipse.birt.report.item.crosstab.core.tests/pom.xml
@@ -27,27 +27,6 @@
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>target-platform-configuration</artifactId>
-				<version>${tycho.version}</version>
-				<configuration>
-					<dependency-resolution>
-						<extraRequirements>
-							<requirement>
-								<type>eclipse-feature</type>
-								<id>org.eclipse.birt.osgi.runtime</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
-							<requirement>
-								<type>eclipse-plugin</type>
-								<id>org.eclipse.birt.report.modelextension.tests</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
-						</extraRequirements>
-					</dependency-resolution>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>


### PR DESCRIPTION
- Remove org.eclipse.birt.report.viewer and org.eclipse.birt.data.oda.mongodb.ui from org.eclipse.birt.osgi.runtime
 feature.
- Simplify test dependency configuration.
- The org.junit dependencies aren't optional and non-test bundles should not have such a dependency, even an optional one.