### PR TITLE
Only disable the failing rendering tests for windows

### DIFF
--- a/build/org.eclipse.birt.target/BIRT Chart Test.launch
+++ b/build/org.eclipse.birt.target/BIRT Chart Test.launch
@@ -38,7 +38,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.birt.chart.tests"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true&#13;&#10;-Dbirt.rendering.tests.enabled=true"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.birt.branding.birt_all_in_one"/>
     <booleanAttribute key="run_in_ui_thread" value="true"/>

--- a/build/org.eclipse.birt.target/BIRT Report Tests Chart Test.launch
+++ b/build/org.eclipse.birt.target/BIRT Report Tests Chart Test.launch
@@ -36,7 +36,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.birt.report.tests.chart"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true&#13;&#10;-Dbirt.rendering.tests.enabled=true"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.sdk.ide"/>
     <booleanAttribute key="run_in_ui_thread" value="true"/>

--- a/chart/org.eclipse.birt.chart.tests/src/org/eclipse/birt/chart/tests/device/render/ImageOutputBaseTest.java
+++ b/chart/org.eclipse.birt.chart.tests/src/org/eclipse/birt/chart/tests/device/render/ImageOutputBaseTest.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.apache.batik.transcoder.TranscoderInput;
 import org.apache.batik.transcoder.TranscoderOutput;
 import org.apache.batik.transcoder.image.PNGTranscoder;
-import org.junit.Ignore;
 
 import junit.framework.TestCase;
 import utility.ImageUtil;
@@ -59,10 +58,9 @@ public class ImageOutputBaseTest extends TestCase {
 	}
 
 	@Override
-	@Ignore("https://github.com/eclipse-birt/birt/issues/1828")
 	public void runTest() throws Throwable {
 
-		if (Boolean.TRUE) {
+		if (!ImageUtil.isRenderingTestApplicable()) {
 			return;
 		}
 

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_101855.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_101855.java
@@ -46,7 +46,7 @@ import org.eclipse.birt.chart.model.type.BarSeries;
 import org.eclipse.birt.chart.model.type.impl.BarSeriesImpl;
 import org.eclipse.birt.chart.util.PluginSettings;
 import org.eclipse.birt.report.tests.chart.ChartTestCase;
-import org.junit.Ignore;
+import org.eclipse.core.runtime.Platform;
 
 /**
  * Regression description:
@@ -117,9 +117,9 @@ public class Regression_101855 extends ChartTestCase {
 		}
 	}
 
-	@Ignore("https://github.com/eclipse-birt/birt/issues/1828")
 	public void test_regression_101855() throws Exception {
-		if (Boolean.TRUE) {
+		if (Platform.getOS().equals(Platform.WS_WIN32)) {
+			// https://github.com/eclipse-birt/birt/issues/1828
 			return;
 		}
 		Regression_101855 st = new Regression_101855();

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_131308.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_131308.java
@@ -42,7 +42,8 @@ import org.eclipse.birt.chart.model.type.AreaSeries;
 import org.eclipse.birt.chart.model.type.impl.AreaSeriesImpl;
 import org.eclipse.birt.chart.util.PluginSettings;
 import org.eclipse.birt.report.tests.chart.ChartTestCase;
-import org.junit.Ignore;
+
+import utility.ImageUtil;
 
 /**
  * Regression description:
@@ -115,9 +116,8 @@ public class Regression_131308 extends ChartTestCase {
 		}
 	}
 
-	@Ignore("https://github.com/eclipse-birt/birt/issues/1828")
 	public void test_regression_131308() throws Exception {
-		if (Boolean.TRUE) {
+		if (!ImageUtil.isRenderingTestApplicable()) {
 			return;
 		}
 		Regression_131308 st = new Regression_131308();

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_133237.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_133237.java
@@ -47,7 +47,8 @@ import org.eclipse.birt.chart.model.type.BarSeries;
 import org.eclipse.birt.chart.model.type.impl.BarSeriesImpl;
 import org.eclipse.birt.chart.util.PluginSettings;
 import org.eclipse.birt.report.tests.chart.ChartTestCase;
-import org.junit.Ignore;
+
+import utility.ImageUtil;
 
 /**
  * Regression description:
@@ -118,9 +119,8 @@ public class Regression_133237 extends ChartTestCase {
 		}
 	}
 
-	@Ignore("https://github.com/eclipse-birt/birt/issues/1828")
 	public void test_regression_133237() throws Exception {
-		if (Boolean.TRUE) {
+		if (!ImageUtil.isRenderingTestApplicable()) {
 			return;
 		}
 		Regression_133237 st = new Regression_133237();

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_134309.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_134309.java
@@ -47,9 +47,10 @@ import org.eclipse.birt.chart.model.type.BarSeries;
 import org.eclipse.birt.chart.model.type.impl.BarSeriesImpl;
 import org.eclipse.birt.chart.util.PluginSettings;
 import org.eclipse.birt.report.tests.chart.ChartTestCase;
-import org.junit.Ignore;
 
 import com.ibm.icu.util.ULocale;
+
+import utility.ImageUtil;
 
 /**
  * Regression description:
@@ -128,9 +129,8 @@ public class Regression_134309 extends ChartTestCase {
 		ULocale.setDefault(new ULocale("en_US"));
 	}
 
-	@Ignore("https://github.com/eclipse-birt/birt/issues/1828")
 	public void test_regression_134309() throws Exception {
-		if (Boolean.TRUE) {
+		if (!ImageUtil.isRenderingTestApplicable()) {
 			return;
 		}
 		Regression_134309 st = new Regression_134309();

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_134885.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_134885.java
@@ -41,7 +41,8 @@ import org.eclipse.birt.chart.model.type.PieSeries;
 import org.eclipse.birt.chart.model.type.impl.PieSeriesImpl;
 import org.eclipse.birt.chart.util.PluginSettings;
 import org.eclipse.birt.report.tests.chart.ChartTestCase;
-import org.junit.Ignore;
+
+import utility.ImageUtil;
 
 /**
  * Regression description:
@@ -113,12 +114,11 @@ public class Regression_134885 extends ChartTestCase {
 		}
 	}
 
-	@Ignore("https://github.com/eclipse-birt/birt/issues/1828")
 	public void test_regression_134885() throws Exception {
-		if (Boolean.TRUE) {
-			return;
-		}
 		if (!"true".equals(System.getProperty("testOnCentos"))) {
+			if (!ImageUtil.isRenderingTestApplicable()) {
+				return;
+			}
 			Regression_134885 st = new Regression_134885();
 			assertTrue(st.compareImages(GOLDEN, OUTPUT));
 		}

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_137166.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_137166.java
@@ -47,7 +47,8 @@ import org.eclipse.birt.chart.model.type.BarSeries;
 import org.eclipse.birt.chart.model.type.impl.BarSeriesImpl;
 import org.eclipse.birt.chart.util.PluginSettings;
 import org.eclipse.birt.report.tests.chart.ChartTestCase;
-import org.junit.Ignore;
+
+import utility.ImageUtil;
 
 /**
  * Regression description:
@@ -120,9 +121,8 @@ public class Regression_137166 extends ChartTestCase {
 		}
 	}
 
-	@Ignore("https://github.com/eclipse-birt/birt/issues/1828")
 	public void test_regression_137166() throws Exception {
-		if (Boolean.TRUE) {
+		if (!ImageUtil.isRenderingTestApplicable()) {
 			return;
 		}
 		Regression_137166 st = new Regression_137166();

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_142689.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_142689.java
@@ -43,7 +43,8 @@ import org.eclipse.birt.chart.model.type.BarSeries;
 import org.eclipse.birt.chart.model.type.impl.BarSeriesImpl;
 import org.eclipse.birt.chart.util.PluginSettings;
 import org.eclipse.birt.report.tests.chart.ChartTestCase;
-import org.junit.Ignore;
+
+import utility.ImageUtil;
 
 /**
  * Regression description:
@@ -114,9 +115,8 @@ public class Regression_142689 extends ChartTestCase {
 		}
 	}
 
-	@Ignore("https://github.com/eclipse-birt/birt/issues/1828")
 	public void test_regression_142689() throws Exception {
-		if (Boolean.TRUE) {
+		if (!ImageUtil.isRenderingTestApplicable()) {
 			return;
 		}
 		Regression_142689 st = new Regression_142689();

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_155185.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_155185.java
@@ -36,7 +36,8 @@ import org.eclipse.birt.chart.model.type.PieSeries;
 import org.eclipse.birt.chart.model.type.impl.PieSeriesImpl;
 import org.eclipse.birt.chart.util.PluginSettings;
 import org.eclipse.birt.report.tests.chart.ChartTestCase;
-import org.junit.Ignore;
+
+import utility.ImageUtil;
 
 /**
  * Regression description:
@@ -107,9 +108,8 @@ public class Regression_155185 extends ChartTestCase {
 		}
 	}
 
-	@Ignore("https://github.com/eclipse-birt/birt/issues/1828")
 	public void test_regression_155185() throws Exception {
-		if (Boolean.TRUE) {
+		if (!ImageUtil.isRenderingTestApplicable()) {
 			return;
 		}
 		Regression_155185 st = new Regression_155185();

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_76910.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_76910.java
@@ -46,7 +46,10 @@ import org.eclipse.birt.chart.model.type.BarSeries;
 import org.eclipse.birt.chart.model.type.impl.BarSeriesImpl;
 import org.eclipse.birt.chart.util.PluginSettings;
 import org.eclipse.birt.report.tests.chart.ChartTestCase;
-import org.junit.Ignore;
+
+import utility.ImageUtil;
+
+import utility.ImageUtil;
 
 /**
  * Regression description:
@@ -117,9 +120,8 @@ public class Regression_76910 extends ChartTestCase {
 		}
 	}
 
-	@Ignore("https://github.com/eclipse-birt/birt/issues/1828")
 	public void test_regression_76910() throws Exception {
-		if (Boolean.TRUE) {
+		if (!ImageUtil.isRenderingTestApplicable()) {
 			return;
 		}
 		Regression_76910 st = new Regression_76910();

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_76963.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_76963.java
@@ -47,7 +47,8 @@ import org.eclipse.birt.chart.model.type.BarSeries;
 import org.eclipse.birt.chart.model.type.impl.BarSeriesImpl;
 import org.eclipse.birt.chart.util.PluginSettings;
 import org.eclipse.birt.report.tests.chart.ChartTestCase;
-import org.junit.Ignore;
+
+import utility.ImageUtil;
 
 /**
  * Regression description:
@@ -118,9 +119,8 @@ public class Regression_76963 extends ChartTestCase {
 		}
 	}
 
-	@Ignore("https://github.com/eclipse-birt/birt/issues/1828")
 	public void test_regression_76963() throws Exception {
-		if (Boolean.TRUE) {
+		if (!ImageUtil.isRenderingTestApplicable()) {
 			return;
 		}
 		Regression_76963 st = new Regression_76963();

--- a/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_98257.java
+++ b/testsuites/org.eclipse.birt.report.tests.chart/src/org/eclipse/birt/report/tests/chart/regression/Regression_98257.java
@@ -46,7 +46,8 @@ import org.eclipse.birt.chart.model.type.BarSeries;
 import org.eclipse.birt.chart.model.type.impl.BarSeriesImpl;
 import org.eclipse.birt.chart.util.PluginSettings;
 import org.eclipse.birt.report.tests.chart.ChartTestCase;
-import org.junit.Ignore;
+
+import utility.ImageUtil;
 
 /**
  * Regression description:
@@ -119,9 +120,8 @@ public class Regression_98257 extends ChartTestCase {
 		}
 	}
 
-	@Ignore("https://github.com/eclipse-birt/birt/issues/1828")
 	public void test_regression_98257() throws Exception {
-		if (Boolean.TRUE) {
+		if (!ImageUtil.isRenderingTestApplicable()) {
 			return;
 		}
 		Regression_98257 st = new Regression_98257();

--- a/testsuites/org.eclipse.birt.tests.core/src/utility/ImageUtil.java
+++ b/testsuites/org.eclipse.birt.tests.core/src/utility/ImageUtil.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import javax.imageio.ImageIO;
 import javax.swing.GrayFilter;
 
+import org.eclipse.core.runtime.Platform;
+
 /*
  * Perform operations on images and image files: read, save, compare etc.
  */
@@ -183,6 +185,13 @@ public class ImageUtil {
 	 */
 	public static Image loadImageFromFile(String filename) throws IOException {
 		return ImageIO.read(new File(filename));
+	}
+
+	/**
+	 * @see https://github.com/eclipse-birt/birt/issues/1828
+	 */
+	public static boolean isRenderingTestApplicable() {
+		return !Platform.getOS().equals(Platform.WS_WIN32) || Boolean.getBoolean("birt.rendering.tests.enabled");
 	}
 
 	public static void main(String[] args) throws IOException {


### PR DESCRIPTION
- Support the `system property birt.rendering.tests.enabled` set to `true` to enable the tests even on Windows and enable it in the IDE launchers where the tests function correctly.

https://github.com/eclipse-birt/birt/issues/1828