### PR TITLE
Fix deadlock when POI tried to initialize its logger

### DIFF
--- a/build/birt-packages/birt-charts/DeploymentRuntime/category.xml
+++ b/build/birt-packages/birt-charts/DeploymentRuntime/category.xml
@@ -20,7 +20,7 @@
    <bundle id="com.ibm.icu">
       <category name="ChartEngine"/>
    </bundle>
-   <bundle id="org.apache.commons.commons-logging">
+   <bundle id="org.apache.commons.logging">
       <category name="ChartEngine"/>
    </bundle>
    <bundle id="org.apache.xml.resolver">

--- a/build/birt-packages/birt-runtime-osgi/build.xml
+++ b/build/birt-packages/birt-runtime-osgi/build.xml
@@ -70,7 +70,7 @@
       <fileset dir="${ENGINE_DIR}/platform/plugins">
         <include name="jakarta.xml.bind-api_*.jar"/>
         <include name="javax.wsdl_*.jar"/>
-        <include name="org.apache.commons.commons-logging_*.jar"/>
+        <include name="org.apache.commons.logging_*.jar"/>
         <include name="org.apache.axis_*.jar"/>
         <include name="org.apache.commons.discovery_*.jar"/>
         <include name="jakarta.inject.jakarta.inject-api_*.jar"/>

--- a/build/org.eclipse.birt.releng/BIRT.setup
+++ b/build/org.eclipse.birt.releng/BIRT.setup
@@ -477,7 +477,7 @@
         </detail>
         <detail
             key="generateVersions">
-          <value>org.mortbay.jasper.apache-.*|jakarta.activation-api|jakarta.xml.bind-api</value>
+          <value>org.mortbay.jasper.apache-.*|jakarta.activation-api|jakarta.xml.bind-api|org.apache.commons.logging</value>
         </detail>
         <detail
             key="minimizeImplicitUnits">
@@ -499,6 +499,8 @@
       <requirement
           name="*"/>
       <requirement
+          name="slf4j.simple"/>
+      <requirement
           name="cdi.api"
           optional="true"
           max="0">
@@ -514,10 +516,6 @@
           optional="true"
           max="0"/>
       <requirement
-          name="org.apache.commons.logging"
-          optional="true"
-          max="0"/>
-      <requirement
           name="javax.xml.soap"
           optional="true"
           max="0"/>
@@ -525,6 +523,13 @@
           name="jakarta.xml.bind"
           optional="true"
           max="0"/>
+      <requirement
+          name="org.apache.commons.commons-logging"
+          optional="true"
+          max="0"/>
+      <requirement
+          name="org.apache.commons.logging"
+          versionRange="[1.2.0,1.2.0]"/>
       <sourceLocator
           rootFolder="${git.clone.birt.location}"
           locateNestedProjects="true"/>
@@ -547,7 +552,7 @@
         <repository
             url="https://download.eclipse.org/tools/gef/classic/nightly/latest"/>
         <repository
-            url="https://download.eclipse.org/webtools/repository/latest"/>
+            url="https://download.eclipse.org/webtools/CI/latest"/>
         <repository
             url="https://download.eclipse.org/justj/epp/milestone/latest"/>
         <repository

--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from BIRT" sequenceNumber="49">
+<target name="Generated from BIRT" sequenceNumber="50">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="bcpg" version="0.0.0"/>
@@ -53,12 +53,13 @@
       <unit id="org.apache.commons.commons-collections4" version="0.0.0"/>
       <unit id="org.apache.commons.commons-compress" version="0.0.0"/>
       <unit id="org.apache.commons.commons-io" version="0.0.0"/>
-      <unit id="org.apache.commons.commons-logging" version="0.0.0"/>
       <unit id="org.apache.commons.discovery" version="0.0.0"/>
+      <unit id="org.apache.commons.logging" version="1.2.0"/>
       <unit id="org.apache.commons.math3" version="0.0.0"/>
       <unit id="org.apache.derby" version="0.0.0"/>
       <unit id="org.apache.felix.scr" version="0.0.0"/>
       <unit id="org.apache.logging.log4j.api" version="0.0.0"/>
+      <unit id="org.apache.logging.log4j.to.slf4j" version="0.0.0"/>
       <unit id="org.apache.lucene.queries" version="0.0.0"/>
       <unit id="org.apache.lucene.sandbox" version="0.0.0"/>
       <unit id="org.apache.poi" version="0.0.0"/>
@@ -144,7 +145,7 @@
       <repository location="https://download.eclipse.org/datatools/updates/milestone/latest"/>
       <repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/latest"/>
       <repository location="https://download.eclipse.org/tools/gef/classic/nightly/latest"/>
-      <repository location="https://download.eclipse.org/webtools/repository/latest"/>
+      <repository location="https://download.eclipse.org/webtools/CI/latest"/>
       <repository location="https://download.eclipse.org/justj/epp/milestone/latest"/>
       <repository location="https://download.eclipse.org/justj/jres/21/updates/release/latest"/>
     </location>

--- a/data/org.eclipse.birt.report.data.oda.excel/META-INF/MANIFEST.MF
+++ b/data/org.eclipse.birt.report.data.oda.excel/META-INF/MANIFEST.MF
@@ -11,10 +11,10 @@ Export-Package: org.eclipse.birt.report.data.oda.excel,
  org.eclipse.birt.report.data.oda.excel.impl;version="1.0.0.qualifier",
  org.eclipse.birt.report.data.oda.excel.impl.util,
  org.eclipse.birt.report.data.oda.excel.impl.util.querytextutil
+Import-Package: org.apache.commons.logging
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.23.0",
  org.eclipse.datatools.connectivity.oda;bundle-version="[3.3.0,4.0.0)",
  org.eclipse.datatools.connectivity.oda.profile;bundle-version="[3.2.0,4.0.0)",
- org.apache.commons.commons-logging;bundle-version="[1.0.4,2.0.0)";resolution:=optional,
  org.apache.poi;bundle-version="[5.0.0,6.0.0)",
  org.apache.poi.ooxml;bundle-version="[5.0.0,6.0.0)",
  org.apache.poi.ooxml.schemas;bundle-version="[5.0.0,6.0.0)",

--- a/engine/uk.co.spudsoft.birt.emitters.excel/META-INF/MANIFEST.MF
+++ b/engine/uk.co.spudsoft.birt.emitters.excel/META-INF/MANIFEST.MF
@@ -17,5 +17,6 @@ Bundle-ActivationPolicy: lazy
 Export-Package: uk.co.spudsoft.birt.emitters.excel,
  uk.co.spudsoft.birt.emitters.excel.framework,
  uk.co.spudsoft.birt.emitters.excel.handlers;x-internal:=true
+Import-Package: org.apache.logging.slf4j
 Eclipse-BundleShape: dir
 Automatic-Module-Name: uk.co.spudsoft.birt.emitters.excel


### PR DESCRIPTION
- Add a dependency to org.apache.logging.log4j.to.slf4j so that org.apache.logging.log4j.api finds a Provider.
- Avoid direct dependencies on org.apache.commons.commons-logging because it's been a source of incompatibility problems in SimRel.
- Update webtools site to use content that's going into SimRel 2024-09.