### PR TITLE
Test org.eclipse.birt.axis.utility.UTF8Encoder is used and is correct

### DIFF
--- a/build/birt-packages/birt-runtime-test/src/test/java/org/eclipse/birt/sdk/BaseTestTemplate.java
+++ b/build/birt-packages/birt-runtime-test/src/test/java/org/eclipse/birt/sdk/BaseTestTemplate.java
@@ -13,6 +13,9 @@ package org.eclipse.birt.sdk;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -23,8 +26,13 @@ import java.nio.file.Paths;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.junit.Assert;
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
 
 /**
  *
@@ -79,6 +87,43 @@ public abstract class BaseTestTemplate {
 				new String(Files.readAllBytes(Paths.get(output)), StandardCharsets.UTF_8).contains("image/svg+xml"));
 	}
 
+	@Test
+	public void testAxisEncoding() throws Exception {
+		Class<?> encoderFactoryClass = getClass("org.apache.axis",
+				"org.apache.axis.components.encoding.XMLEncoderFactory");
+		Method getEncoderMethod = encoderFactoryClass.getMethod("getEncoder", String.class);
+		Object encoder = getEncoderMethod.invoke(null, "UTF-8");
+
+		String originalValue = "\ud800\udc00\uD83D\uDC7D";
+		int codePointCount = originalValue.codePointCount(0, originalValue.length());
+		Assert.assertEquals("The string represents two code points", 2, codePointCount);
+
+		StringWriter writer = new StringWriter();
+		getEncoderMethod.getReturnType().getMethod("writeEncoded", Writer.class, String.class).invoke(encoder, writer,
+				originalValue);
+
+		// An incorrect encoding would produce this:
+		// &#xD800;&#xDC00;&#xD83D;&#xDC7D;
+		//
+		// The parser would fail as follows:
+		// Character reference "&#xD800" is an invalid XML character.
+		//
+		String encodedValue = writer.toString();
+
+		Assert.assertEquals("The two unicode code points should be encoded as two entities", "&#x10000;&#x1F47D;",
+				encodedValue);
+
+		String xml = new String("<?xml version='1.0' encoding='UTF-8'?>\n<document value='" + encodedValue + "'/>");
+
+		Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+				.parse(new InputSource(new StringReader(xml)));
+		Element element = document.getDocumentElement();
+		String decodedValue = element.getAttribute("value");
+
+		Assert.assertEquals("Parser XML with the entities should decode to the original value.", originalValue,
+				decodedValue);
+	}
+
 	protected File[] listJars(String folder) {
 		return new File(folder).listFiles(new FilenameFilter() {
 			@Override
@@ -108,7 +153,11 @@ public abstract class BaseTestTemplate {
 		return new URLClassLoader(urls.toArray(new URL[urls.size()]));
 	}
 
-	public abstract int run(String[] args) throws Exception;
+	protected abstract Class<?> getClass(String bundle, String className) throws Exception;
+
+	public int run(String[] args) throws Exception {
+		return run(getClass("org.eclipse.birt.report.engine", "org.eclipse.birt.report.engine.api.ReportRunner"), args);
+	}
 
 	protected int run(Class<?> mainClass, String[] args) throws Exception {
 		Constructor<?> constructor = mainClass.getConstructor(String[].class);

--- a/build/birt-packages/birt-runtime-test/src/test/java/org/eclipse/birt/sdk/RuntimeOSGiTest.java
+++ b/build/birt-packages/birt-runtime-test/src/test/java/org/eclipse/birt/sdk/RuntimeOSGiTest.java
@@ -19,7 +19,9 @@ import java.lang.reflect.Method;
 
 @SuppressWarnings("javadoc")
 public class RuntimeOSGiTest extends BaseTestTemplate {
-	public int run(String[] args) throws Exception {
+
+	@Override
+	protected Class<?> getClass(String bundle, String className) throws Exception {
 		System.setProperty("BIRT_HOME",
 				new File("./target/birt-runtime-osgi/ReportEngine/platform/").getAbsolutePath());
 
@@ -43,14 +45,14 @@ public class RuntimeOSGiTest extends BaseTestTemplate {
 		// Get the org.eclipse.birt.report.engine bundle from the launcher.
 		Method getBundleMethod = launcher.getClass().getDeclaredMethod("getBundle", String.class);
 		getBundleMethod.setAccessible(true);
-		Object birtReportEngineBundle = getBundleMethod.invoke(launcher, "org.eclipse.birt.report.engine");
+		Object birtReportEngineBundle = getBundleMethod.invoke(launcher, bundle);
 
 		// Load the org.eclipse.birt.report.engine.api.ReportRunner class from the
 		// bundle to ensure we have loaded the instance class from the actual OSGi
 		// runtime..c
 		Method loadClassMethod = birtReportEngineBundle.getClass().getMethod("loadClass", String.class);
-		Class<?> mainClass = (Class<?>) loadClassMethod.invoke(birtReportEngineBundle,
-				"org.eclipse.birt.report.engine.api.ReportRunner");
-		return run(mainClass, args);
+		Class<?> mainClass = (Class<?>) loadClassMethod.invoke(birtReportEngineBundle, className);
+		return mainClass;
 	}
+
 }

--- a/build/birt-packages/birt-runtime-test/src/test/java/org/eclipse/birt/sdk/RuntimeTest.java
+++ b/build/birt-packages/birt-runtime-test/src/test/java/org/eclipse/birt/sdk/RuntimeTest.java
@@ -17,11 +17,10 @@ package org.eclipse.birt.sdk;
 public class RuntimeTest extends BaseTestTemplate {
 
 	@Override
-	public int run(String[] args) throws Exception {
+	protected Class<?> getClass(String bundle, String className) throws Exception {
 		System.clearProperty("BIRT_HOME");
 		ClassLoader loader = createClassLoader("./target/birt-runtime/ReportEngine/lib"); //$NON-NLS-1$
-		Class<?> mainClass = loader.loadClass("org.eclipse.birt.report.engine.api.ReportRunner"); //$NON-NLS-1$
-
-		return run(mainClass, args);
+		Class<?> mainClass = loader.loadClass(className); // $NON-NLS-1$
+		return mainClass;
 	}
 }

--- a/features/org.eclipse.birt.engine.runtime/feature.xml
+++ b/features/org.eclipse.birt.engine.runtime/feature.xml
@@ -38,10 +38,6 @@
       <discovery label="%updateSiteName" url="https://download.eclipse.org/birt/updates/release/latest"/>
    </url>
 
-   <requires>
-      <import plugin="org.apache.axis"/>
-   </requires>
-
    <plugin
          id="org.eclipse.birt.core"
          version="0.0.0"/>
@@ -263,9 +259,11 @@
          version="0.0.0"/>
 
    <plugin
-         id="uk.co.spudsoft.birt.emitters.excel"
+         id="org.eclipse.birt.axis.overlay"
          version="0.0.0"/>
 
-
+   <plugin
+         id="uk.co.spudsoft.birt.emitters.excel"
+         version="0.0.0"/>
 
 </feature>

--- a/features/org.eclipse.birt.osgi.runtime/feature.xml
+++ b/features/org.eclipse.birt.osgi.runtime/feature.xml
@@ -83,10 +83,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.birt.resources"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.birt.report.engine.dataextraction"
          version="0.0.0"/>
 
@@ -128,6 +124,10 @@
 
    <plugin
          id="org.eclipse.birt.chart.device.extension"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.birt.chart.device.pdf"
          version="0.0.0"/>
 
    <plugin
@@ -248,6 +248,10 @@
 
    <plugin
          id="org.eclipse.birt.report.engine.emitter.pptx"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.birt.report.engine.emitter.prototype.excel"
          version="0.0.0"/>
 
    <plugin

--- a/viewer/org.eclipse.birt.report.viewer.tests/test/org/eclipse/birt/report/viewer/utility/AxisEncodingTest.java
+++ b/viewer/org.eclipse.birt.report.viewer.tests/test/org/eclipse/birt/report/viewer/utility/AxisEncodingTest.java
@@ -1,0 +1,62 @@
+/*************************************************************************************
+ * Copyright (c) 2024 Eclipse contributors and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ ************************************************************************************/
+
+package org.eclipse.birt.report.viewer.utility;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.apache.axis.components.encoding.XMLEncoder;
+import org.apache.axis.components.encoding.XMLEncoderFactory;
+import org.eclipse.birt.report.viewer.util.BaseTestCase;
+import org.junit.Assert;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+
+@SuppressWarnings("javadoc")
+public class AxisEncodingTest extends BaseTestCase {
+
+	public void testEncoding() throws Exception {
+
+		XMLEncoder encoder = XMLEncoderFactory.getEncoder(XMLEncoderFactory.ENCODING_UTF_8);
+		// encoder = new org.apache.axis.components.encoding.DefaultXMLEncoder("UTF-8");
+
+		String originalValue = "\ud800\udc00\uD83D\uDC7D";
+		int codePointCount = originalValue.codePointCount(0, originalValue.length());
+		Assert.assertEquals("The string represents two code points", 2, codePointCount);
+
+		StringWriter writer = new StringWriter();
+		encoder.writeEncoded(writer, originalValue);
+
+		// An incorrect encoding would produce this:
+		// &#xD800;&#xDC00;&#xD83D;&#xDC7D;
+		//
+		// The parser would fail as follows:
+		// Character reference "&#xD800" is an invalid XML character.
+		//
+		String encodedValue = writer.toString();
+		Assert.assertEquals("The two unicode code points should be encoded as two entities", "&#x10000;&#x1F47D;",
+				encodedValue);
+
+		String xml = new String("<?xml version='1.0' encoding='UTF-8'?>\n<document value='" + encodedValue + "'/>");
+
+		Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+				.parse(new InputSource(new StringReader(xml)));
+		Element element = document.getDocumentElement();
+		String decodedValue = element.getAttribute("value");
+
+		Assert.assertEquals("Parser XML with the entities should decode to the original value.", originalValue,
+				decodedValue);
+	}
+}


### PR DESCRIPTION
- Include org.eclipse.birt.axis.overlay in the org.eclipse.birt.engine.runtime feature.
- Test both runtimes that they use the overlay correctly.
- Reconcile the difference between the features org.eclipse.birt.osgi.runtime and org.eclipse.birt.engine.runtime.
  - Remove org.eclipse.birt.resources because it only provides cheatsheet content for in the IDE.
  - Add org.eclipse.birt.chart.device.pdf and org.eclipse.birt.report.engine.emitter.prototype.excel.