### PR TITLE
Simplify the org.eclipse.birt.engine.runtime product

### DIFF
--- a/build/birt-packages/birt-runtime-osgi/reportengine.product
+++ b/build/birt-packages/birt-runtime-osgi/reportengine.product
@@ -173,8 +173,7 @@ United States, other countries, or both.
    </plugins>
 
    <features>
-      <feature id="org.eclipse.birt.engine.runtime"/>
-      <feature id="org.eclipse.birt.chart.osgi.runtime"/>
+      <feature id="org.eclipse.birt.osgi.runtime"/>
    </features>
 
    <configurations>


### PR DESCRIPTION
- Include only the org.eclipse.birt.osgi.runtime feature.