### PR TITLE
Enhance the update site to include all all-in-one product features

### DIFF
--- a/build/birt-packages/birt-report-all-in-one/BIRT.product
+++ b/build/birt-packages/birt-report-all-in-one/BIRT.product
@@ -37,7 +37,8 @@ Powered by the Eclipse Platform: https://eclipse.org/eclipse
       <programArgs>-perspective org.eclipse.birt.report.designer.ui.ReportPerspective
 -product org.eclipse.birt.branding.birt_all_in_one
       </programArgs>
-      <vmArgs>-Xms512m
+      <vmArgs>-Dosgi.requiredJavaVersion=21
+-Xms512m
 -Xmx2048m
 -Dorg.eclipse.help.webapp.experimental.ui=true
       </vmArgs>
@@ -280,6 +281,10 @@ United States, other countries, or both.
       <property name="osgi.instance.area.default" value="@user.home/workspace"/>
       <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx"/>
    </configurations>
+
+   <repositories>
+      <repository location="https://download.eclipse.org/birt/updates/release/latest" name="BIRT Latest Release" enabled="true" />
+   </repositories>
 
    <preferencesInfo>
       <targetfile overwrite="false"/>

--- a/build/org.eclipse.birt.p2updatesite/category.xml
+++ b/build/org.eclipse.birt.p2updatesite/category.xml
@@ -107,6 +107,7 @@
    <feature id="org.eclipse.datatools.common.doc.user"/>
    <feature id="org.eclipse.datatools.connectivity.doc.user"/>
    <feature id="org.eclipse.datatools.enablement.apache.derby.feature"/>
+   <feature id="org.eclipse.datatools.enablement.feature"/>
    <feature id="org.eclipse.datatools.enablement.hsqldb.feature"/>
    <feature id="org.eclipse.datatools.enablement.ibm.feature"/>
    <feature id="org.eclipse.datatools.enablement.ingres.feature"/>
@@ -134,6 +135,11 @@
    <feature id="org.eclipse.help"/>
    <feature id="org.eclipse.platform"/>
    <feature id="org.eclipse.rcp"/>
+   <feature id="org.eclipse.wst.common_core.feature"/>
+   <feature id="org.eclipse.wst.common_ui.feature"/>
+   <feature id="org.eclipse.wst.xml_core.feature"/>
+   <feature id="org.eclipse.wst.xml_ui.feature"/>
+   <feature id="org.eclipse.wst.xml_userdoc.feature"/>
    <feature id="org.eclipse.xsd"/>
    <feature id="org.eclipse.xsd.edit"/>
 


### PR DESCRIPTION
- This allows an all-in-one product installation to be provisioned purely from the BIRT update site.
- With that possibility, Oomph can generate a product definition for use in the installer just like it does for the EPP products and the Platform's SDK product.