### PR TITLE
The preview does not work anymore: #1901

### DIFF
--- a/UI/org.eclipse.birt.report.designer.ui.preview.static_html/src/org/eclipse/birt/report/designer/ui/viewer/StaticHTMLViewer.java
+++ b/UI/org.eclipse.birt.report.designer.ui.preview.static_html/src/org/eclipse/birt/report/designer/ui/viewer/StaticHTMLViewer.java
@@ -772,12 +772,12 @@ public class StaticHTMLViewer extends SWTAbstractViewer {
 			public void work(IProgressMonitor monitor) {
 				monitor.subTask("Show report in Browser"); //$NON-NLS-1$
 				if (!form.isDisposed()) {
-					// browser.setUrl( outputLocation
-					// + ( currentBookmark == null ? ""
-					// : ( "#" + currentBookmark ) ) );
-					browser.setUrl(outputLocation);
-					// if special the anchor, SWT browser will not refresh
-					// browser.refresh( );
+					try {
+						String url = new File(outputLocation).toURI().toURL().toString();
+						browser.setUrl(url);
+					} catch (Exception e) {
+						browser.setUrl(outputLocation);
+					}
 					if (currentPageNum < totalPageNum) {
 						navNextAction.setEnabled(true);
 						navLastAction.setEnabled(true);

--- a/UI/org.eclipse.birt.report.designer.ui.preview/plugin.properties
+++ b/UI/org.eclipse.birt.report.designer.ui.preview/plugin.properties
@@ -17,8 +17,8 @@ designer.preview.previewtoolbarmenuaction.label=View Report
 designer.preview.previewcascadingmenugroup.label=View &Report
 ActionSet.Preview=Preview
 
-template.preview=New Preview Pro&totype
-design.preview=New Preview Pro&totype
+template.preview=Pre&view
+design.preview=Pre&view
 
 preference.preview=Preview
 preference.preview.server=Preview Server

--- a/UI/org.eclipse.birt.report.designer.ui.preview/src/org/eclipse/birt/report/designer/ui/preview/editors/ReportPreviewFormPage.java
+++ b/UI/org.eclipse.birt.report.designer.ui.preview/src/org/eclipse/birt/report/designer/ui/preview/editors/ReportPreviewFormPage.java
@@ -22,11 +22,14 @@ import org.eclipse.birt.report.designer.ui.preview.extension.IViewer;
 import org.eclipse.birt.report.designer.ui.preview.extension.ViewerExtensionManager;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.gef.ui.actions.ActionRegistry;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorSite;
 import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.forms.IManagedForm;
 import org.eclipse.ui.forms.editor.FormEditor;
 import org.eclipse.ui.part.EditorPart;
@@ -64,15 +67,17 @@ public class ReportPreviewFormPage extends EditorPart implements IReportEditorPa
 		reportViewer = manager.createViewer(VIEWER_ID);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.eclipse.birt.report.designer.ui.editors.IReportEditorPage#onBroughtToTop(
-	 * org.eclipse.birt.report.designer.ui.editors.IReportEditorPage)
-	 */
 	@Override
 	public boolean onBroughtToTop(IReportEditorPage prePage) {
+		if (editor.isDirty()) {
+			int SAVEBUTTON = 0;
+			int buttonPressed = MessageDialog.open(MessageDialog.QUESTION, getSite().getShell(),
+					"Save Report", "Save the report so that the preview can show the latest changes?",
+					SWT.SHEET, "Save", "Don't Save");
+			if (buttonPressed == SAVEBUTTON) {
+				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().saveEditor(editor, false);
+			}
+		}
 		startRender();
 		return true;
 	}
@@ -319,6 +324,11 @@ public class ReportPreviewFormPage extends EditorPart implements IReportEditorPa
 	 */
 	@Override
 	public void doSave(IProgressMonitor monitor) {
+		IReportProvider provider = getProvider();
+		if (provider != null) {
+			provider.saveReport(provider.queryReportModuleHandle(), getEditorInput(), monitor);
+			firePropertyChange(PROP_DIRTY);
+		}
 	}
 
 	/*
@@ -352,11 +362,6 @@ public class ReportPreviewFormPage extends EditorPart implements IReportEditorPa
 		return false;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.eclipse.ui.part.WorkbenchPart#setFocus()
-	 */
 	@Override
 	public void setFocus() {
 	}


### PR DESCRIPTION
After switching the default browser to Edge in issues #1736 and #1737 the preview pane was broken because Edge does not like plain filenames.

Fixed:

1. Convert the plain file name to a file URL

This also fixed:

* Ask to save the editor when it is dirty and Preview is requested. #1902
* 'New Preview Prototype' tab must be called Preview #1903