### PR TITLE
Fix the correct PPTX handling of hyperlink decoration

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.pptx/src/org/eclipse/birt/report/engine/emitter/pptx/PPTXCanvas.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pptx/src/org/eclipse/birt/report/engine/emitter/pptx/PPTXCanvas.java
@@ -462,7 +462,8 @@ public class PPTXCanvas {
 	}
 
 	void setHyperlink(HyperlinkDef link) {// TODO: set links for bookmark
-		if (link != null) {
+		// power point doesn't support undecorated hyperlink
+		if (link != null && link.isHasHyperlinkDecoration()) {
 			String hyperlink = null;
 			try {
 				hyperlink = URLEncoder.encode(link.getLink(), "UTF-8");

--- a/engine/org.eclipse.birt.report.engine.emitter.pptx/src/org/eclipse/birt/report/engine/emitter/pptx/TextWriter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pptx/src/org/eclipse/birt/report/engine/emitter/pptx/TextWriter.java
@@ -381,9 +381,7 @@ public class TextWriter {
 		}
 		canvas.setBackgroundColor(style.getColor());
 		setTextFont(info.getFontName());
-		if (link != null && link.isHasHyperlinkDecoration()) {
-			canvas.setHyperlink(link);
-		}
+		canvas.setHyperlink(link);
 		canvas.setBookmark(bmk_relationshipid);
 		writer.closeTag(tag);
 	}
@@ -424,9 +422,7 @@ public class TextWriter {
 			writer.attribute("id", shapeId);
 			writer.attribute("name", "TextBox " + shapeId);
 			// hyperlink decoration at text area
-			if (link != null && !link.isHasHyperlinkDecoration()) {
-				canvas.setHyperlink(link);
-			}
+			canvas.setHyperlink(link);
 			writer.closeTag("p:cNvPr");
 			writer.openTag("p:cNvSpPr");
 			writer.attribute("txBox", "1");


### PR DESCRIPTION
The hyperlink undecoration won't be supported through PPTX because the PresentationML doesn't defined an option to avoid hyperlink decoration. The undecoration of a hyperlink will remove the the hyperlink on PPTX.