### PR TITLE
Update the setup and the target platform specify permanent sites

### DIFF
--- a/build/org.eclipse.birt.releng/BIRT.setup
+++ b/build/org.eclipse.birt.releng/BIRT.setup
@@ -5,6 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:git="http://www.eclipse.org/oomph/setup/git/1.0"
     xmlns:jdt="http://www.eclipse.org/oomph/setup/jdt/1.0"
+    xmlns:p2="http://www.eclipse.org/oomph/p2/1.0"
     xmlns:predicates="http://www.eclipse.org/oomph/predicates/1.0"
     xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
     xmlns:setup.targlets="http://www.eclipse.org/oomph/setup/targlets/1.0"
@@ -415,13 +416,13 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="birt.version"
-      value="latest">
+      value="4.18">
     <choice
         value="latest"
         label="BIRT Latest"/>
     <choice
-        value="4.17"
-        label="BIRT 4.17"/>
+        value="4.18"
+        label="BIRT 4.18"/>
   </setupTask>
   <setupTask
       xsi:type="setup:RedirectionTask"
@@ -555,19 +556,26 @@
             url="https://download.eclipse.org/justj/jres/21/updates/release/latest"/>
       </repositoryList>
       <repositoryList
-          name="4.17">
+          name="4.18">
+        <annotation>
+          <content
+              xsi:type="p2:Repository"
+              url="https://download.eclipse.org/datatools/updates/release/1.16.2"/>
+        </annotation>
         <repository
             url="https://download.eclipse.org/cbi/updates/license"/>
         <repository
-            url="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.33.0"/>
+            url="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.34.0"/>
         <repository
-            url="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/release/12.0.12"/>
+            url="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/release/12.0.15"/>
         <repository
-            url="https://download.eclipse.org/releases/2024-09/202409111000"/>
+            url="https://download.eclipse.org/releases/2024-12/202412041000"/>
         <repository
-            url="https://download.eclipse.org/justj/epp/release/21.0.0.v20240807-1553"/>
+            url="https://download.eclipse.org/justj/epp/release/21.0.0.v20241024-0603"/>
         <repository
             url="https://download.eclipse.org/justj/jres/21/updates/release/latest"/>
+        <repository
+            url="https://download.eclipse.org/datatools/updates/milestone/latest"/>
       </repositoryList>
     </targlet>
   </setupTask>

--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from BIRT" sequenceNumber="53">
+<target name="Generated from BIRT" sequenceNumber="54">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="bcpg" version="0.0.0"/>
@@ -145,16 +145,13 @@
       <unit id="org.osgi.service.repository" version="0.0.0"/>
       <unit id="slf4j.api" version="0.0.0"/>
       <unit id="slf4j.simple" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/eclipse/updates/4.34-I-builds"/>
       <repository location="https://download.eclipse.org/cbi/updates/license"/>
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest"/>
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/release/latest"/>
-      <repository location="https://download.eclipse.org/datatools/updates/milestone/latest"/>
-      <repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/latest"/>
-      <repository location="https://download.eclipse.org/tools/gef/classic/nightly/latest"/>
-      <repository location="https://download.eclipse.org/webtools/CI/latest"/>
-      <repository location="https://download.eclipse.org/justj/epp/milestone/latest"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.34.0"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/release/12.0.15"/>
+      <repository location="https://download.eclipse.org/releases/2024-12/202412041000"/>
+      <repository location="https://download.eclipse.org/justj/epp/release/21.0.0.v20241024-0603"/>
       <repository location="https://download.eclipse.org/justj/jres/21/updates/release/latest"/>
+      <repository location="https://download.eclipse.org/datatools/updates/milestone/latest"/>
     </location>
   </locations>
 </target>


### PR DESCRIPTION
- The setup change is temporary until 4.19 development begins.
- Similarly the target platform will be regenerated to moving-target sites when 4.19 begins.
- Only the datatools site is still a moving target pending a 1.16.2 release.

https://github.com/eclipse-birt/birt/issues/1910