### PR TITLE
BIRT OSGi, copy org.apache.commons.commons-logging to the lib-folder

### DIFF
--- a/build/birt-packages/birt-runtime-osgi/build.xml
+++ b/build/birt-packages/birt-runtime-osgi/build.xml
@@ -70,7 +70,7 @@
       <fileset dir="${ENGINE_DIR}/platform/plugins">
         <include name="jakarta.xml.bind-api_*.jar"/>
         <include name="javax.wsdl_*.jar"/>
-        <include name="org.apache.commons.logging_*.jar"/>
+        <include name="org.apache.commons.commons-logging_*.jar"/>
         <include name="org.apache.axis_*.jar"/>
         <include name="org.apache.commons.discovery_*.jar"/>
         <include name="jakarta.inject.jakarta.inject-api_*.jar"/>


### PR DESCRIPTION
The logging factory is switched from "org.apache.commons.logging" to "org.apache.commons.commons-logging" and must be copied from platform/plugins-folder to the WEB-INF/lib-folder.