### PR TITLE
PDF/UA support, part 2

### DIFF
--- a/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/core/model/schematic/TableHandleAdapter.java
+++ b/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/core/model/schematic/TableHandleAdapter.java
@@ -59,7 +59,7 @@ public class TableHandleAdapter extends ReportItemtHandleAdapter {
 	private static final String NAME_NULL = ""; //$NON-NLS-1$
 	private static final String NAME_DETAIL = Messages.getString("TableHandleAdapter.name.detail"); //$NON-NLS-1$
 	private static final String NAME_FOOTER = Messages.getString("TableHandleAdapter.name.footer"); //$NON-NLS-1$
-	private static final String NAME_HEADRER = Messages.getString("TableHandleAdapter.name.header"); //$NON-NLS-1$
+	private static final String NAME_HEADER = Messages.getString("TableHandleAdapter.name.header"); //$NON-NLS-1$
 	private static final String TRANS_LABEL_NOT_INCLUDE = Messages
 			.getString("TableHandleAdapter.transLabel.notInclude"); //$NON-NLS-1$
 	private static final String TRANS_LABEL_INCLUDE = Messages.getString("TableHandleAdapter.transLabel.include"); //$NON-NLS-1$
@@ -1502,7 +1502,7 @@ public class TableHandleAdapter extends ReportItemtHandleAdapter {
 	protected static String getOperationName(int id) {
 		switch (id) {
 		case HEADER:
-			return NAME_HEADRER;
+			return NAME_HEADER;
 		case FOOTER:
 			return NAME_FOOTER;
 		case DETAIL:

--- a/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/.project
+++ b/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>pdf-ua</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.birt.report.designer.ui.reportprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/HyperlinkHTML.rptdesign
+++ b/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/HyperlinkHTML.rptdesign
@@ -2,12 +2,12 @@
 <report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.26" id="1">
     <property name="author">Henning von Bargen</property>
     <property name="createdBy">Eclipse BIRT Designer Version 4.18.0.qualifier Build &lt;@BUILD@></property>
-    <text-property name="title">A table with a group header</text-property>
+    <text-property name="title">Das ist der Titel</text-property>
     <property name="units">in</property>
     <property name="iconFile">/templates/blank_report.gif</property>
     <property name="bidiLayoutOrientation">ltr</property>
     <property name="imageDPI">96</property>
-    <property name="locale">en_US</property>
+    <property name="locale">de_DE</property>
     <property name="pdfVersion">1.7</property>
     <property name="pdfConformance">PDF.A1A</property>
     <property name="pdfUAConformance">PDF.UA-1</property>
@@ -46,34 +46,10 @@
                     <text-property name="heading">PRODUCTNAME</text-property>
                 </structure>
                 <structure>
-                    <property name="columnName">PRODUCTLINE</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTLINE</text-property>
-                    <text-property name="heading">PRODUCTLINE</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">PRODUCTSCALE</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTSCALE</text-property>
-                    <text-property name="heading">PRODUCTSCALE</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">PRODUCTVENDOR</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTVENDOR</text-property>
-                    <text-property name="heading">PRODUCTVENDOR</text-property>
-                </structure>
-                <structure>
                     <property name="columnName">PRODUCTDESCRIPTION</property>
                     <property name="analysis">dimension</property>
                     <text-property name="displayName">PRODUCTDESCRIPTION</text-property>
                     <text-property name="heading">PRODUCTDESCRIPTION</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">QUANTITYINSTOCK</property>
-                    <property name="analysis">measure</property>
-                    <text-property name="displayName">QUANTITYINSTOCK</text-property>
-                    <text-property name="heading">QUANTITYINSTOCK</text-property>
                 </structure>
                 <structure>
                     <property name="columnName">BUYPRICE</property>
@@ -82,10 +58,16 @@
                     <text-property name="heading">BUYPRICE</text-property>
                 </structure>
                 <structure>
-                    <property name="columnName">MSRP</property>
-                    <property name="analysis">measure</property>
-                    <text-property name="displayName">MSRP</text-property>
-                    <text-property name="heading">MSRP</text-property>
+                    <property name="columnName">PRODUCTLINE</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">PRODUCTLINE</text-property>
+                    <text-property name="heading">PRODUCTLINE</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">HTMLDESCRIPTION</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">HTMLDESCRIPTION</text-property>
+                    <text-property name="heading">HTMLDESCRIPTION</text-property>
                 </structure>
             </list-property>
             <list-property name="parameters"/>
@@ -103,42 +85,27 @@
                     </structure>
                     <structure>
                         <property name="position">3</property>
-                        <property name="name">PRODUCTLINE</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">4</property>
-                        <property name="name">PRODUCTSCALE</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">5</property>
-                        <property name="name">PRODUCTVENDOR</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">6</property>
                         <property name="name">PRODUCTDESCRIPTION</property>
                         <property name="dataType">string</property>
                     </structure>
                     <structure>
-                        <property name="position">7</property>
-                        <property name="name">QUANTITYINSTOCK</property>
-                        <property name="dataType">integer</property>
-                    </structure>
-                    <structure>
-                        <property name="position">8</property>
+                        <property name="position">4</property>
                         <property name="name">BUYPRICE</property>
                         <property name="dataType">float</property>
                     </structure>
                     <structure>
-                        <property name="position">9</property>
-                        <property name="name">MSRP</property>
-                        <property name="dataType">float</property>
+                        <property name="position">5</property>
+                        <property name="name">PRODUCTLINE</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">6</property>
+                        <property name="name">HTMLDESCRIPTION</property>
+                        <property name="dataType">string</property>
                     </structure>
                 </list-property>
             </structure>
-            <property name="rowFetchLimit">6</property>
+            <property name="rowFetchLimit">100</property>
             <property name="dataSource">CM</property>
             <list-property name="resultSet">
                 <structure>
@@ -157,57 +124,42 @@
                 </structure>
                 <structure>
                     <property name="position">3</property>
-                    <property name="name">PRODUCTLINE</property>
-                    <property name="nativeName">PRODUCTLINE</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">4</property>
-                    <property name="name">PRODUCTSCALE</property>
-                    <property name="nativeName">PRODUCTSCALE</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">5</property>
-                    <property name="name">PRODUCTVENDOR</property>
-                    <property name="nativeName">PRODUCTVENDOR</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">6</property>
                     <property name="name">PRODUCTDESCRIPTION</property>
                     <property name="nativeName">PRODUCTDESCRIPTION</property>
                     <property name="dataType">string</property>
                     <property name="nativeDataType">12</property>
                 </structure>
                 <structure>
-                    <property name="position">7</property>
-                    <property name="name">QUANTITYINSTOCK</property>
-                    <property name="nativeName">QUANTITYINSTOCK</property>
-                    <property name="dataType">integer</property>
-                    <property name="nativeDataType">4</property>
-                </structure>
-                <structure>
-                    <property name="position">8</property>
+                    <property name="position">4</property>
                     <property name="name">BUYPRICE</property>
                     <property name="nativeName">BUYPRICE</property>
                     <property name="dataType">float</property>
                     <property name="nativeDataType">8</property>
                 </structure>
                 <structure>
-                    <property name="position">9</property>
-                    <property name="name">MSRP</property>
-                    <property name="nativeName">MSRP</property>
-                    <property name="dataType">float</property>
-                    <property name="nativeDataType">8</property>
+                    <property name="position">5</property>
+                    <property name="name">PRODUCTLINE</property>
+                    <property name="nativeName">PRODUCTLINE</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">6</property>
+                    <property name="name">HTMLDESCRIPTION</property>
+                    <property name="nativeName">HTMLDESCRIPTION</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">2005</property>
                 </structure>
             </list-property>
-            <xml-property name="queryText"><![CDATA[select *
+            <xml-property name="queryText"><![CDATA[select products.productcode
+     , products.productname
+     , products.productdescription
+     , products.buyprice
+     , products.productline
+     , productlines.htmldescription
 from products
-order by productline, productname]]></xml-property>
+join productlines on (products.productline = productlines.productline)
+order by products.productline, products.productname]]></xml-property>
             <xml-property name="designerValues"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
 <model:DesignValues xmlns:design="http://www.eclipse.org/datatools/connectivity/oda/design" xmlns:model="http://www.eclipse.org/birt/report/model/adapter/odaModel">
   <Version>2.0</Version>
@@ -418,114 +370,12 @@ order by productline, productname]]></xml-property>
     <page-setup>
         <simple-master-page name="Simple MasterPage" id="2">
             <property name="type">a4</property>
-            <page-header>
-                <label id="7">
-                    <text-property name="text">Das ist ein Label im Header der MasterPage</text-property>
-                </label>
-            </page-header>
         </simple-master-page>
     </page-setup>
     <body>
-        <table id="35">
-            <property name="dataSet">Products</property>
-            <list-property name="boundDataColumns">
-                <structure>
-                    <property name="name">PRODUCTNAME</property>
-                    <text-property name="displayName">PRODUCTNAME</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["PRODUCTNAME"]</expression>
-                    <property name="dataType">string</property>
-                </structure>
-                <structure>
-                    <property name="name">PRODUCTLINE</property>
-                    <text-property name="displayName">PRODUCTLINE</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["PRODUCTLINE"]</expression>
-                    <property name="dataType">string</property>
-                </structure>
-                <structure>
-                    <property name="name">PRODUCTDESCRIPTION</property>
-                    <text-property name="displayName">PRODUCTDESCRIPTION</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["PRODUCTDESCRIPTION"]</expression>
-                    <property name="dataType">string</property>
-                </structure>
-                <structure>
-                    <property name="name">MSRP</property>
-                    <text-property name="displayName">MSRP</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["MSRP"]</expression>
-                    <property name="dataType">float</property>
-                </structure>
-            </list-property>
-            <property name="pageBreakInterval">9999</property>
-            <column id="59"/>
-            <column id="61"/>
-            <column id="62"/>
-            <header>
-                <row id="36">
-                    <property name="backgroundColor">#80FF00</property>
-                    <cell id="37">
-                        <expression name="bookmark" type="javascript">"product"</expression>
-                        <label id="38">
-                            <text-property name="text">Product Name</text-property>
-                        </label>
-                    </cell>
-                    <cell id="41">
-                        <expression name="bookmark" type="javascript">"descr"</expression>
-                        <label id="42">
-                            <text-property name="text">Description</text-property>
-                        </label>
-                    </cell>
-                    <cell id="43">
-                        <expression name="bookmark" type="javascript">"price"</expression>
-                        <label id="44">
-                            <text-property name="text">Price</text-property>
-                        </label>
-                    </cell>
-                </row>
-            </header>
-            <group id="63">
-                <property name="groupName">TDProductLine</property>
-                <expression name="keyExpr" type="javascript">row["PRODUCTLINE"]</expression>
-                <expression name="bookmark" type="javascript">row["PRODUCTLINE"]</expression>
-                <structure name="toc">
-                    <expression name="expressionValue" type="javascript">row["PRODUCTLINE"]</expression>
-                </structure>
-                <property name="hideDetail">false</property>
-                <header>
-                    <row id="64">
-                        <cell id="65">
-                            <property name="colSpan">3</property>
-                            <property name="rowSpan">1</property>
-                            <expression name="bookmark" type="javascript">"bm-" + row["PRODUCTLINE"]</expression>
-                            <property name="tagType">TH</property>
-                            <property name="backgroundColor">#80FFFF</property>
-                            <data id="74">
-                                <property name="resultSetColumn">PRODUCTLINE</property>
-                            </data>
-                        </cell>
-                    </row>
-                </header>
-            </group>
-            <detail>
-                <row id="45">
-                    <cell id="46">
-                        <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",product"</expression>
-                        <data id="47">
-                            <property name="resultSetColumn">PRODUCTNAME</property>
-                        </data>
-                    </cell>
-                    <cell id="50">
-                        <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",descr"</expression>
-                        <data id="51">
-                            <property name="resultSetColumn">PRODUCTDESCRIPTION</property>
-                        </data>
-                    </cell>
-                    <cell id="52">
-                        <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",price"</expression>
-                        <data id="53">
-                            <property name="resultSetColumn">MSRP</property>
-                        </data>
-                    </cell>
-                </row>
-            </detail>
-        </table>
+        <text-data id="101">
+            <expression name="valueExpr">'&lt;p>Text with &lt;a href="https://github.com/eclipse-birt/birt">hyperlink&lt;/a>&lt;/p>'</expression>
+            <property name="contentType">html</property>
+        </text-data>
     </body>
 </report>

--- a/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/HyperlinkImage.rptdesign
+++ b/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/HyperlinkImage.rptdesign
@@ -9,9 +9,8 @@
     <property name="imageDPI">96</property>
     <property name="locale">de_DE</property>
     <property name="pdfVersion">1.7</property>
-    <property name="pdfConformance">PDF.A3A</property>
+    <property name="pdfConformance">PDF.A1A</property>
     <property name="pdfUAConformance">PDF.UA-1</property>
-    <property name="pdfaFontCidEmbed">false</property>
     <property name="pdfaDocumentTitleEmbed">true</property>
     <styles>
         <style name="report" id="6">
@@ -21,16 +20,37 @@
     <page-setup>
         <simple-master-page name="Simple MasterPage" id="2">
             <property name="type">a4</property>
+            <page-header>
+                <label id="7">
+                    <text-property name="text">Das ist ein Label im Header der MasterPage</text-property>
+                </label>
+            </page-header>
         </simple-master-page>
     </page-setup>
     <body>
-        <label id="4">
+        <label id="8">
             <property name="fontSize">12pt</property>
-            <text-property name="text">Das ist die Überschrift</text-property>
+            <property name="fontWeight">bold</property>
+            <text-property name="text">Überschrift auf Ebene 1</text-property>
             <property name="tagType">H1</property>
         </label>
         <label id="5">
             <text-property name="text">Und das ist normaler Text.</text-property>
         </label>
+        <image id="13">
+            <property name="height">5.171717171717172in</property>
+            <property name="width">5.171717171717172in</property>
+            <expression name="altText">"Eine gemalte Sonne mit Gesicht"</expression>
+            <property name="source">file</property>
+            <expression name="uri" type="constant">./sonne.png</expression>
+            <list-property name="action">
+                <structure>
+                    <property name="linkType">hyperlink</property>
+                    <property name="toolTip">Die Website der Eclipse Stiftung</property>
+                    <expression name="uri" type="constant">https://eclipse.org</expression>
+                    <property name="targetWindow">_blank</property>
+                </structure>
+            </list-property>
+        </image>
     </body>
 </report>

--- a/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/HyperlinkLabel.rptdesign
+++ b/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/HyperlinkLabel.rptdesign
@@ -9,7 +9,7 @@
     <property name="imageDPI">96</property>
     <property name="locale">de_DE</property>
     <property name="pdfVersion">1.7</property>
-    <property name="pdfConformance">PDF.A1A</property>
+    <property name="pdfConformance">PDF.A3A</property>
     <property name="pdfUAConformance">PDF.UA-1</property>
     <property name="pdfaFontCidEmbed">false</property>
     <property name="pdfaDocumentTitleEmbed">true</property>

--- a/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/HyperlinkLabel.rptdesign
+++ b/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/HyperlinkLabel.rptdesign
@@ -2,15 +2,16 @@
 <report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.26" id="1">
     <property name="author">Henning von Bargen</property>
     <property name="createdBy">Eclipse BIRT Designer Version 4.18.0.qualifier Build &lt;@BUILD@></property>
-    <text-property name="title">A table with a group header</text-property>
+    <text-property name="title">Das ist der Titel</text-property>
     <property name="units">in</property>
     <property name="iconFile">/templates/blank_report.gif</property>
     <property name="bidiLayoutOrientation">ltr</property>
     <property name="imageDPI">96</property>
-    <property name="locale">en_US</property>
+    <property name="locale">de_DE</property>
     <property name="pdfVersion">1.7</property>
     <property name="pdfConformance">PDF.A1A</property>
     <property name="pdfUAConformance">PDF.UA-1</property>
+    <property name="pdfaFontCidEmbed">false</property>
     <property name="pdfaDocumentTitleEmbed">true</property>
     <data-sources>
         <oda-data-source extensionID="org.eclipse.birt.report.data.oda.jdbc" name="CM" id="14">
@@ -46,34 +47,10 @@
                     <text-property name="heading">PRODUCTNAME</text-property>
                 </structure>
                 <structure>
-                    <property name="columnName">PRODUCTLINE</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTLINE</text-property>
-                    <text-property name="heading">PRODUCTLINE</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">PRODUCTSCALE</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTSCALE</text-property>
-                    <text-property name="heading">PRODUCTSCALE</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">PRODUCTVENDOR</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTVENDOR</text-property>
-                    <text-property name="heading">PRODUCTVENDOR</text-property>
-                </structure>
-                <structure>
                     <property name="columnName">PRODUCTDESCRIPTION</property>
                     <property name="analysis">dimension</property>
                     <text-property name="displayName">PRODUCTDESCRIPTION</text-property>
                     <text-property name="heading">PRODUCTDESCRIPTION</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">QUANTITYINSTOCK</property>
-                    <property name="analysis">measure</property>
-                    <text-property name="displayName">QUANTITYINSTOCK</text-property>
-                    <text-property name="heading">QUANTITYINSTOCK</text-property>
                 </structure>
                 <structure>
                     <property name="columnName">BUYPRICE</property>
@@ -82,10 +59,16 @@
                     <text-property name="heading">BUYPRICE</text-property>
                 </structure>
                 <structure>
-                    <property name="columnName">MSRP</property>
-                    <property name="analysis">measure</property>
-                    <text-property name="displayName">MSRP</text-property>
-                    <text-property name="heading">MSRP</text-property>
+                    <property name="columnName">PRODUCTLINE</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">PRODUCTLINE</text-property>
+                    <text-property name="heading">PRODUCTLINE</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">HTMLDESCRIPTION</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">HTMLDESCRIPTION</text-property>
+                    <text-property name="heading">HTMLDESCRIPTION</text-property>
                 </structure>
             </list-property>
             <list-property name="parameters"/>
@@ -103,42 +86,27 @@
                     </structure>
                     <structure>
                         <property name="position">3</property>
-                        <property name="name">PRODUCTLINE</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">4</property>
-                        <property name="name">PRODUCTSCALE</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">5</property>
-                        <property name="name">PRODUCTVENDOR</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">6</property>
                         <property name="name">PRODUCTDESCRIPTION</property>
                         <property name="dataType">string</property>
                     </structure>
                     <structure>
-                        <property name="position">7</property>
-                        <property name="name">QUANTITYINSTOCK</property>
-                        <property name="dataType">integer</property>
-                    </structure>
-                    <structure>
-                        <property name="position">8</property>
+                        <property name="position">4</property>
                         <property name="name">BUYPRICE</property>
                         <property name="dataType">float</property>
                     </structure>
                     <structure>
-                        <property name="position">9</property>
-                        <property name="name">MSRP</property>
-                        <property name="dataType">float</property>
+                        <property name="position">5</property>
+                        <property name="name">PRODUCTLINE</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">6</property>
+                        <property name="name">HTMLDESCRIPTION</property>
+                        <property name="dataType">string</property>
                     </structure>
                 </list-property>
             </structure>
-            <property name="rowFetchLimit">6</property>
+            <property name="rowFetchLimit">100</property>
             <property name="dataSource">CM</property>
             <list-property name="resultSet">
                 <structure>
@@ -157,57 +125,42 @@
                 </structure>
                 <structure>
                     <property name="position">3</property>
-                    <property name="name">PRODUCTLINE</property>
-                    <property name="nativeName">PRODUCTLINE</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">4</property>
-                    <property name="name">PRODUCTSCALE</property>
-                    <property name="nativeName">PRODUCTSCALE</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">5</property>
-                    <property name="name">PRODUCTVENDOR</property>
-                    <property name="nativeName">PRODUCTVENDOR</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">6</property>
                     <property name="name">PRODUCTDESCRIPTION</property>
                     <property name="nativeName">PRODUCTDESCRIPTION</property>
                     <property name="dataType">string</property>
                     <property name="nativeDataType">12</property>
                 </structure>
                 <structure>
-                    <property name="position">7</property>
-                    <property name="name">QUANTITYINSTOCK</property>
-                    <property name="nativeName">QUANTITYINSTOCK</property>
-                    <property name="dataType">integer</property>
-                    <property name="nativeDataType">4</property>
-                </structure>
-                <structure>
-                    <property name="position">8</property>
+                    <property name="position">4</property>
                     <property name="name">BUYPRICE</property>
                     <property name="nativeName">BUYPRICE</property>
                     <property name="dataType">float</property>
                     <property name="nativeDataType">8</property>
                 </structure>
                 <structure>
-                    <property name="position">9</property>
-                    <property name="name">MSRP</property>
-                    <property name="nativeName">MSRP</property>
-                    <property name="dataType">float</property>
-                    <property name="nativeDataType">8</property>
+                    <property name="position">5</property>
+                    <property name="name">PRODUCTLINE</property>
+                    <property name="nativeName">PRODUCTLINE</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">6</property>
+                    <property name="name">HTMLDESCRIPTION</property>
+                    <property name="nativeName">HTMLDESCRIPTION</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">2005</property>
                 </structure>
             </list-property>
-            <xml-property name="queryText"><![CDATA[select *
+            <xml-property name="queryText"><![CDATA[select products.productcode
+     , products.productname
+     , products.productdescription
+     , products.buyprice
+     , products.productline
+     , productlines.htmldescription
 from products
-order by productline, productname]]></xml-property>
+join productlines on (products.productline = productlines.productline)
+order by products.productline, products.productname]]></xml-property>
             <xml-property name="designerValues"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
 <model:DesignValues xmlns:design="http://www.eclipse.org/datatools/connectivity/oda/design" xmlns:model="http://www.eclipse.org/birt/report/model/adapter/odaModel">
   <Version>2.0</Version>
@@ -418,114 +371,20 @@ order by productline, productname]]></xml-property>
     <page-setup>
         <simple-master-page name="Simple MasterPage" id="2">
             <property name="type">a4</property>
-            <page-header>
-                <label id="7">
-                    <text-property name="text">Das ist ein Label im Header der MasterPage</text-property>
-                </label>
-            </page-header>
         </simple-master-page>
     </page-setup>
     <body>
-        <table id="35">
-            <property name="dataSet">Products</property>
-            <list-property name="boundDataColumns">
+        <label id="103">
+            <property name="backgroundColor">#D0D0E0</property>
+            <text-property name="text">This is a label with a tooltip.</text-property>
+            <list-property name="action">
                 <structure>
-                    <property name="name">PRODUCTNAME</property>
-                    <text-property name="displayName">PRODUCTNAME</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["PRODUCTNAME"]</expression>
-                    <property name="dataType">string</property>
-                </structure>
-                <structure>
-                    <property name="name">PRODUCTLINE</property>
-                    <text-property name="displayName">PRODUCTLINE</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["PRODUCTLINE"]</expression>
-                    <property name="dataType">string</property>
-                </structure>
-                <structure>
-                    <property name="name">PRODUCTDESCRIPTION</property>
-                    <text-property name="displayName">PRODUCTDESCRIPTION</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["PRODUCTDESCRIPTION"]</expression>
-                    <property name="dataType">string</property>
-                </structure>
-                <structure>
-                    <property name="name">MSRP</property>
-                    <text-property name="displayName">MSRP</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["MSRP"]</expression>
-                    <property name="dataType">float</property>
+                    <property name="linkType">hyperlink</property>
+                    <property name="toolTip">The Eclipse web site</property>
+                    <expression name="uri" type="constant">https://eclipse.org</expression>
+                    <property name="targetWindow">_blank</property>
                 </structure>
             </list-property>
-            <property name="pageBreakInterval">9999</property>
-            <column id="59"/>
-            <column id="61"/>
-            <column id="62"/>
-            <header>
-                <row id="36">
-                    <property name="backgroundColor">#80FF00</property>
-                    <cell id="37">
-                        <expression name="bookmark" type="javascript">"product"</expression>
-                        <label id="38">
-                            <text-property name="text">Product Name</text-property>
-                        </label>
-                    </cell>
-                    <cell id="41">
-                        <expression name="bookmark" type="javascript">"descr"</expression>
-                        <label id="42">
-                            <text-property name="text">Description</text-property>
-                        </label>
-                    </cell>
-                    <cell id="43">
-                        <expression name="bookmark" type="javascript">"price"</expression>
-                        <label id="44">
-                            <text-property name="text">Price</text-property>
-                        </label>
-                    </cell>
-                </row>
-            </header>
-            <group id="63">
-                <property name="groupName">TDProductLine</property>
-                <expression name="keyExpr" type="javascript">row["PRODUCTLINE"]</expression>
-                <expression name="bookmark" type="javascript">row["PRODUCTLINE"]</expression>
-                <structure name="toc">
-                    <expression name="expressionValue" type="javascript">row["PRODUCTLINE"]</expression>
-                </structure>
-                <property name="hideDetail">false</property>
-                <header>
-                    <row id="64">
-                        <cell id="65">
-                            <property name="colSpan">3</property>
-                            <property name="rowSpan">1</property>
-                            <expression name="bookmark" type="javascript">"bm-" + row["PRODUCTLINE"]</expression>
-                            <property name="tagType">TH</property>
-                            <property name="backgroundColor">#80FFFF</property>
-                            <data id="74">
-                                <property name="resultSetColumn">PRODUCTLINE</property>
-                            </data>
-                        </cell>
-                    </row>
-                </header>
-            </group>
-            <detail>
-                <row id="45">
-                    <cell id="46">
-                        <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",product"</expression>
-                        <data id="47">
-                            <property name="resultSetColumn">PRODUCTNAME</property>
-                        </data>
-                    </cell>
-                    <cell id="50">
-                        <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",descr"</expression>
-                        <data id="51">
-                            <property name="resultSetColumn">PRODUCTDESCRIPTION</property>
-                        </data>
-                    </cell>
-                    <cell id="52">
-                        <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",price"</expression>
-                        <data id="53">
-                            <property name="resultSetColumn">MSRP</property>
-                        </data>
-                    </cell>
-                </row>
-            </detail>
-        </table>
+        </label>
     </body>
 </report>

--- a/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/complexTableHTML.rptdesign
+++ b/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/complexTableHTML.rptdesign
@@ -2,7 +2,7 @@
 <report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.26" id="1">
     <property name="author">Henning von Bargen</property>
     <property name="createdBy">Eclipse BIRT Designer Version 4.18.0.qualifier Build &lt;@BUILD@></property>
-    <text-property name="title">A table with a group header</text-property>
+    <text-property name="title">This is the document title</text-property>
     <property name="units">in</property>
     <property name="iconFile">/templates/blank_report.gif</property>
     <property name="bidiLayoutOrientation">ltr</property>
@@ -11,6 +11,7 @@
     <property name="pdfVersion">1.7</property>
     <property name="pdfConformance">PDF.A1A</property>
     <property name="pdfUAConformance">PDF.UA-1</property>
+    <property name="pdfaFontCidEmbed">true</property>
     <property name="pdfaDocumentTitleEmbed">true</property>
     <data-sources>
         <oda-data-source extensionID="org.eclipse.birt.report.data.oda.jdbc" name="CM" id="14">
@@ -46,34 +47,10 @@
                     <text-property name="heading">PRODUCTNAME</text-property>
                 </structure>
                 <structure>
-                    <property name="columnName">PRODUCTLINE</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTLINE</text-property>
-                    <text-property name="heading">PRODUCTLINE</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">PRODUCTSCALE</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTSCALE</text-property>
-                    <text-property name="heading">PRODUCTSCALE</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">PRODUCTVENDOR</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTVENDOR</text-property>
-                    <text-property name="heading">PRODUCTVENDOR</text-property>
-                </structure>
-                <structure>
                     <property name="columnName">PRODUCTDESCRIPTION</property>
                     <property name="analysis">dimension</property>
                     <text-property name="displayName">PRODUCTDESCRIPTION</text-property>
                     <text-property name="heading">PRODUCTDESCRIPTION</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">QUANTITYINSTOCK</property>
-                    <property name="analysis">measure</property>
-                    <text-property name="displayName">QUANTITYINSTOCK</text-property>
-                    <text-property name="heading">QUANTITYINSTOCK</text-property>
                 </structure>
                 <structure>
                     <property name="columnName">BUYPRICE</property>
@@ -82,10 +59,16 @@
                     <text-property name="heading">BUYPRICE</text-property>
                 </structure>
                 <structure>
-                    <property name="columnName">MSRP</property>
-                    <property name="analysis">measure</property>
-                    <text-property name="displayName">MSRP</text-property>
-                    <text-property name="heading">MSRP</text-property>
+                    <property name="columnName">PRODUCTLINE</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">PRODUCTLINE</text-property>
+                    <text-property name="heading">PRODUCTLINE</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">HTMLDESCRIPTION</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">HTMLDESCRIPTION</text-property>
+                    <text-property name="heading">HTMLDESCRIPTION</text-property>
                 </structure>
             </list-property>
             <list-property name="parameters"/>
@@ -103,42 +86,27 @@
                     </structure>
                     <structure>
                         <property name="position">3</property>
-                        <property name="name">PRODUCTLINE</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">4</property>
-                        <property name="name">PRODUCTSCALE</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">5</property>
-                        <property name="name">PRODUCTVENDOR</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">6</property>
                         <property name="name">PRODUCTDESCRIPTION</property>
                         <property name="dataType">string</property>
                     </structure>
                     <structure>
-                        <property name="position">7</property>
-                        <property name="name">QUANTITYINSTOCK</property>
-                        <property name="dataType">integer</property>
-                    </structure>
-                    <structure>
-                        <property name="position">8</property>
+                        <property name="position">4</property>
                         <property name="name">BUYPRICE</property>
                         <property name="dataType">float</property>
                     </structure>
                     <structure>
-                        <property name="position">9</property>
-                        <property name="name">MSRP</property>
-                        <property name="dataType">float</property>
+                        <property name="position">5</property>
+                        <property name="name">PRODUCTLINE</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">6</property>
+                        <property name="name">HTMLDESCRIPTION</property>
+                        <property name="dataType">string</property>
                     </structure>
                 </list-property>
             </structure>
-            <property name="rowFetchLimit">6</property>
+            <property name="rowFetchLimit">100</property>
             <property name="dataSource">CM</property>
             <list-property name="resultSet">
                 <structure>
@@ -157,57 +125,42 @@
                 </structure>
                 <structure>
                     <property name="position">3</property>
-                    <property name="name">PRODUCTLINE</property>
-                    <property name="nativeName">PRODUCTLINE</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">4</property>
-                    <property name="name">PRODUCTSCALE</property>
-                    <property name="nativeName">PRODUCTSCALE</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">5</property>
-                    <property name="name">PRODUCTVENDOR</property>
-                    <property name="nativeName">PRODUCTVENDOR</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">6</property>
                     <property name="name">PRODUCTDESCRIPTION</property>
                     <property name="nativeName">PRODUCTDESCRIPTION</property>
                     <property name="dataType">string</property>
                     <property name="nativeDataType">12</property>
                 </structure>
                 <structure>
-                    <property name="position">7</property>
-                    <property name="name">QUANTITYINSTOCK</property>
-                    <property name="nativeName">QUANTITYINSTOCK</property>
-                    <property name="dataType">integer</property>
-                    <property name="nativeDataType">4</property>
-                </structure>
-                <structure>
-                    <property name="position">8</property>
+                    <property name="position">4</property>
                     <property name="name">BUYPRICE</property>
                     <property name="nativeName">BUYPRICE</property>
                     <property name="dataType">float</property>
                     <property name="nativeDataType">8</property>
                 </structure>
                 <structure>
-                    <property name="position">9</property>
-                    <property name="name">MSRP</property>
-                    <property name="nativeName">MSRP</property>
-                    <property name="dataType">float</property>
-                    <property name="nativeDataType">8</property>
+                    <property name="position">5</property>
+                    <property name="name">PRODUCTLINE</property>
+                    <property name="nativeName">PRODUCTLINE</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">6</property>
+                    <property name="name">HTMLDESCRIPTION</property>
+                    <property name="nativeName">HTMLDESCRIPTION</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">2005</property>
                 </structure>
             </list-property>
-            <xml-property name="queryText"><![CDATA[select *
+            <xml-property name="queryText"><![CDATA[select products.productcode
+     , products.productname
+     , products.productdescription
+     , products.buyprice
+     , products.productline
+     , productlines.htmldescription
 from products
-order by productline, productname]]></xml-property>
+join productlines on (products.productline = productlines.productline)
+order by products.productline, products.productname]]></xml-property>
             <xml-property name="designerValues"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
 <model:DesignValues xmlns:design="http://www.eclipse.org/datatools/connectivity/oda/design" xmlns:model="http://www.eclipse.org/birt/report/model/adapter/odaModel">
   <Version>2.0</Version>
@@ -448,13 +401,26 @@ order by productline, productname]]></xml-property>
                     <property name="dataType">string</property>
                 </structure>
                 <structure>
-                    <property name="name">MSRP</property>
-                    <text-property name="displayName">MSRP</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["MSRP"]</expression>
+                    <property name="name">PRODUCTCODE</property>
+                    <text-property name="displayName">PRODUCTCODE</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["PRODUCTCODE"]</expression>
+                    <property name="dataType">string</property>
+                </structure>
+                <structure>
+                    <property name="name">BUYPRICE</property>
+                    <text-property name="displayName">BUYPRICE</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["BUYPRICE"]</expression>
                     <property name="dataType">float</property>
+                </structure>
+                <structure>
+                    <property name="name">HTMLDESCRIPTION</property>
+                    <text-property name="displayName">HTMLDESCRIPTION</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["HTMLDESCRIPTION"]</expression>
+                    <property name="dataType">string</property>
                 </structure>
             </list-property>
             <property name="pageBreakInterval">9999</property>
+            <text-property name="caption">This is the table caption!</text-property>
             <column id="59"/>
             <column id="61"/>
             <column id="62"/>
@@ -488,24 +454,27 @@ order by productline, productname]]></xml-property>
                 <structure name="toc">
                     <expression name="expressionValue" type="javascript">row["PRODUCTLINE"]</expression>
                 </structure>
+                <property name="repeatHeader">false</property>
                 <property name="hideDetail">false</property>
                 <header>
                     <row id="64">
+                        <property name="pageBreakInside">auto</property>
                         <cell id="65">
                             <property name="colSpan">3</property>
                             <property name="rowSpan">1</property>
                             <expression name="bookmark" type="javascript">"bm-" + row["PRODUCTLINE"]</expression>
-                            <property name="tagType">TH</property>
                             <property name="backgroundColor">#80FFFF</property>
-                            <data id="74">
-                                <property name="resultSetColumn">PRODUCTLINE</property>
-                            </data>
+                            <text-data id="76">
+                                <expression name="valueExpr">row["HTMLDESCRIPTION"]</expression>
+                                <property name="contentType">html</property>
+                            </text-data>
                         </cell>
                     </row>
                 </header>
             </group>
             <detail>
                 <row id="45">
+                    <property name="pageBreakInside">auto</property>
                     <cell id="46">
                         <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",product"</expression>
                         <data id="47">
@@ -520,8 +489,8 @@ order by productline, productname]]></xml-property>
                     </cell>
                     <cell id="52">
                         <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",price"</expression>
-                        <data id="53">
-                            <property name="resultSetColumn">MSRP</property>
+                        <data id="77">
+                            <property name="resultSetColumn">BUYPRICE</property>
                         </data>
                     </cell>
                 </row>

--- a/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/complextTable.rptdesign
+++ b/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/complextTable.rptdesign
@@ -2,7 +2,7 @@
 <report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.26" id="1">
     <property name="author">Henning von Bargen</property>
     <property name="createdBy">Eclipse BIRT Designer Version 4.18.0.qualifier Build &lt;@BUILD@></property>
-    <text-property name="title">A table with a group header</text-property>
+    <text-property name="title">Example of a table</text-property>
     <property name="units">in</property>
     <property name="iconFile">/templates/blank_report.gif</property>
     <property name="bidiLayoutOrientation">ltr</property>
@@ -46,34 +46,10 @@
                     <text-property name="heading">PRODUCTNAME</text-property>
                 </structure>
                 <structure>
-                    <property name="columnName">PRODUCTLINE</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTLINE</text-property>
-                    <text-property name="heading">PRODUCTLINE</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">PRODUCTSCALE</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTSCALE</text-property>
-                    <text-property name="heading">PRODUCTSCALE</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">PRODUCTVENDOR</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTVENDOR</text-property>
-                    <text-property name="heading">PRODUCTVENDOR</text-property>
-                </structure>
-                <structure>
                     <property name="columnName">PRODUCTDESCRIPTION</property>
                     <property name="analysis">dimension</property>
                     <text-property name="displayName">PRODUCTDESCRIPTION</text-property>
                     <text-property name="heading">PRODUCTDESCRIPTION</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">QUANTITYINSTOCK</property>
-                    <property name="analysis">measure</property>
-                    <text-property name="displayName">QUANTITYINSTOCK</text-property>
-                    <text-property name="heading">QUANTITYINSTOCK</text-property>
                 </structure>
                 <structure>
                     <property name="columnName">BUYPRICE</property>
@@ -82,10 +58,16 @@
                     <text-property name="heading">BUYPRICE</text-property>
                 </structure>
                 <structure>
-                    <property name="columnName">MSRP</property>
-                    <property name="analysis">measure</property>
-                    <text-property name="displayName">MSRP</text-property>
-                    <text-property name="heading">MSRP</text-property>
+                    <property name="columnName">PRODUCTLINE</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">PRODUCTLINE</text-property>
+                    <text-property name="heading">PRODUCTLINE</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">HTMLDESCRIPTION</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">HTMLDESCRIPTION</text-property>
+                    <text-property name="heading">HTMLDESCRIPTION</text-property>
                 </structure>
             </list-property>
             <list-property name="parameters"/>
@@ -103,42 +85,27 @@
                     </structure>
                     <structure>
                         <property name="position">3</property>
-                        <property name="name">PRODUCTLINE</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">4</property>
-                        <property name="name">PRODUCTSCALE</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">5</property>
-                        <property name="name">PRODUCTVENDOR</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">6</property>
                         <property name="name">PRODUCTDESCRIPTION</property>
                         <property name="dataType">string</property>
                     </structure>
                     <structure>
-                        <property name="position">7</property>
-                        <property name="name">QUANTITYINSTOCK</property>
-                        <property name="dataType">integer</property>
-                    </structure>
-                    <structure>
-                        <property name="position">8</property>
+                        <property name="position">4</property>
                         <property name="name">BUYPRICE</property>
                         <property name="dataType">float</property>
                     </structure>
                     <structure>
-                        <property name="position">9</property>
-                        <property name="name">MSRP</property>
-                        <property name="dataType">float</property>
+                        <property name="position">5</property>
+                        <property name="name">PRODUCTLINE</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">6</property>
+                        <property name="name">HTMLDESCRIPTION</property>
+                        <property name="dataType">string</property>
                     </structure>
                 </list-property>
             </structure>
-            <property name="rowFetchLimit">6</property>
+            <property name="rowFetchLimit">100</property>
             <property name="dataSource">CM</property>
             <list-property name="resultSet">
                 <structure>
@@ -157,57 +124,42 @@
                 </structure>
                 <structure>
                     <property name="position">3</property>
-                    <property name="name">PRODUCTLINE</property>
-                    <property name="nativeName">PRODUCTLINE</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">4</property>
-                    <property name="name">PRODUCTSCALE</property>
-                    <property name="nativeName">PRODUCTSCALE</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">5</property>
-                    <property name="name">PRODUCTVENDOR</property>
-                    <property name="nativeName">PRODUCTVENDOR</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">6</property>
                     <property name="name">PRODUCTDESCRIPTION</property>
                     <property name="nativeName">PRODUCTDESCRIPTION</property>
                     <property name="dataType">string</property>
                     <property name="nativeDataType">12</property>
                 </structure>
                 <structure>
-                    <property name="position">7</property>
-                    <property name="name">QUANTITYINSTOCK</property>
-                    <property name="nativeName">QUANTITYINSTOCK</property>
-                    <property name="dataType">integer</property>
-                    <property name="nativeDataType">4</property>
-                </structure>
-                <structure>
-                    <property name="position">8</property>
+                    <property name="position">4</property>
                     <property name="name">BUYPRICE</property>
                     <property name="nativeName">BUYPRICE</property>
                     <property name="dataType">float</property>
                     <property name="nativeDataType">8</property>
                 </structure>
                 <structure>
-                    <property name="position">9</property>
-                    <property name="name">MSRP</property>
-                    <property name="nativeName">MSRP</property>
-                    <property name="dataType">float</property>
-                    <property name="nativeDataType">8</property>
+                    <property name="position">5</property>
+                    <property name="name">PRODUCTLINE</property>
+                    <property name="nativeName">PRODUCTLINE</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">6</property>
+                    <property name="name">HTMLDESCRIPTION</property>
+                    <property name="nativeName">HTMLDESCRIPTION</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">2005</property>
                 </structure>
             </list-property>
-            <xml-property name="queryText"><![CDATA[select *
+            <xml-property name="queryText"><![CDATA[select products.productcode
+     , products.productname
+     , products.productdescription
+     , products.buyprice
+     , products.productline
+     , productlines.htmldescription
 from products
-order by productline, productname]]></xml-property>
+join productlines on (products.productline = productlines.productline)
+order by products.productline, products.productname]]></xml-property>
             <xml-property name="designerValues"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
 <model:DesignValues xmlns:design="http://www.eclipse.org/datatools/connectivity/oda/design" xmlns:model="http://www.eclipse.org/birt/report/model/adapter/odaModel">
   <Version>2.0</Version>
@@ -448,13 +400,26 @@ order by productline, productname]]></xml-property>
                     <property name="dataType">string</property>
                 </structure>
                 <structure>
-                    <property name="name">MSRP</property>
-                    <text-property name="displayName">MSRP</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["MSRP"]</expression>
+                    <property name="name">PRODUCTCODE</property>
+                    <text-property name="displayName">PRODUCTCODE</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["PRODUCTCODE"]</expression>
+                    <property name="dataType">string</property>
+                </structure>
+                <structure>
+                    <property name="name">BUYPRICE</property>
+                    <text-property name="displayName">BUYPRICE</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["BUYPRICE"]</expression>
                     <property name="dataType">float</property>
+                </structure>
+                <structure>
+                    <property name="name">HTMLDESCRIPTION</property>
+                    <text-property name="displayName">HTMLDESCRIPTION</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["HTMLDESCRIPTION"]</expression>
+                    <property name="dataType">string</property>
                 </structure>
             </list-property>
             <property name="pageBreakInterval">9999</property>
+            <text-property name="caption">This is the table caption!</text-property>
             <column id="59"/>
             <column id="61"/>
             <column id="62"/>
@@ -488,24 +453,27 @@ order by productline, productname]]></xml-property>
                 <structure name="toc">
                     <expression name="expressionValue" type="javascript">row["PRODUCTLINE"]</expression>
                 </structure>
+                <property name="repeatHeader">false</property>
                 <property name="hideDetail">false</property>
                 <header>
                     <row id="64">
+                        <property name="pageBreakInside">auto</property>
                         <cell id="65">
                             <property name="colSpan">3</property>
                             <property name="rowSpan">1</property>
                             <expression name="bookmark" type="javascript">"bm-" + row["PRODUCTLINE"]</expression>
-                            <property name="tagType">TH</property>
                             <property name="backgroundColor">#80FFFF</property>
-                            <data id="74">
-                                <property name="resultSetColumn">PRODUCTLINE</property>
-                            </data>
+                            <text-data id="76">
+                                <expression name="valueExpr">row["HTMLDESCRIPTION"]</expression>
+                                <property name="contentType">html</property>
+                            </text-data>
                         </cell>
                     </row>
                 </header>
             </group>
             <detail>
                 <row id="45">
+                    <property name="pageBreakInside">auto</property>
                     <cell id="46">
                         <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",product"</expression>
                         <data id="47">
@@ -520,8 +488,8 @@ order by productline, productname]]></xml-property>
                     </cell>
                     <cell id="52">
                         <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",price"</expression>
-                        <data id="53">
-                            <property name="resultSetColumn">MSRP</property>
+                        <data id="77">
+                            <property name="resultSetColumn">BUYPRICE</property>
                         </data>
                     </cell>
                 </row>

--- a/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/grid_only.rptdesign
+++ b/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/grid_only.rptdesign
@@ -2,7 +2,7 @@
 <report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.26" id="1">
     <property name="author">Henning von Bargen</property>
     <property name="createdBy">Eclipse BIRT Designer Version 4.18.0.qualifier Build &lt;@BUILD@></property>
-    <text-property name="title">A table with a group header</text-property>
+    <text-property name="title">Just a grid</text-property>
     <property name="units">in</property>
     <property name="iconFile">/templates/blank_report.gif</property>
     <property name="bidiLayoutOrientation">ltr</property>
@@ -138,7 +138,7 @@
                     </structure>
                 </list-property>
             </structure>
-            <property name="rowFetchLimit">6</property>
+            <property name="rowFetchLimit">50</property>
             <property name="dataSource">CM</property>
             <list-property name="resultSet">
                 <structure>
@@ -426,9 +426,15 @@ order by productline, productname]]></xml-property>
         </simple-master-page>
     </page-setup>
     <body>
-        <table id="35">
+        <grid id="75">
             <property name="dataSet">Products</property>
             <list-property name="boundDataColumns">
+                <structure>
+                    <property name="name">PRODUCTCODE</property>
+                    <text-property name="displayName">PRODUCTCODE</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["PRODUCTCODE"]</expression>
+                    <property name="dataType">string</property>
+                </structure>
                 <structure>
                     <property name="name">PRODUCTNAME</property>
                     <text-property name="displayName">PRODUCTNAME</text-property>
@@ -442,10 +448,34 @@ order by productline, productname]]></xml-property>
                     <property name="dataType">string</property>
                 </structure>
                 <structure>
+                    <property name="name">PRODUCTSCALE</property>
+                    <text-property name="displayName">PRODUCTSCALE</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["PRODUCTSCALE"]</expression>
+                    <property name="dataType">string</property>
+                </structure>
+                <structure>
+                    <property name="name">PRODUCTVENDOR</property>
+                    <text-property name="displayName">PRODUCTVENDOR</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["PRODUCTVENDOR"]</expression>
+                    <property name="dataType">string</property>
+                </structure>
+                <structure>
                     <property name="name">PRODUCTDESCRIPTION</property>
                     <text-property name="displayName">PRODUCTDESCRIPTION</text-property>
                     <expression name="expression" type="javascript">dataSetRow["PRODUCTDESCRIPTION"]</expression>
                     <property name="dataType">string</property>
+                </structure>
+                <structure>
+                    <property name="name">QUANTITYINSTOCK</property>
+                    <text-property name="displayName">QUANTITYINSTOCK</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["QUANTITYINSTOCK"]</expression>
+                    <property name="dataType">integer</property>
+                </structure>
+                <structure>
+                    <property name="name">BUYPRICE</property>
+                    <text-property name="displayName">BUYPRICE</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["BUYPRICE"]</expression>
+                    <property name="dataType">float</property>
                 </structure>
                 <structure>
                     <property name="name">MSRP</property>
@@ -454,78 +484,189 @@ order by productline, productname]]></xml-property>
                     <property name="dataType">float</property>
                 </structure>
             </list-property>
-            <property name="pageBreakInterval">9999</property>
-            <column id="59"/>
-            <column id="61"/>
-            <column id="62"/>
-            <header>
-                <row id="36">
-                    <property name="backgroundColor">#80FF00</property>
-                    <cell id="37">
-                        <expression name="bookmark" type="javascript">"product"</expression>
-                        <label id="38">
-                            <text-property name="text">Product Name</text-property>
-                        </label>
-                    </cell>
-                    <cell id="41">
-                        <expression name="bookmark" type="javascript">"descr"</expression>
-                        <label id="42">
-                            <text-property name="text">Description</text-property>
-                        </label>
-                    </cell>
-                    <cell id="43">
-                        <expression name="bookmark" type="javascript">"price"</expression>
-                        <label id="44">
-                            <text-property name="text">Price</text-property>
-                        </label>
-                    </cell>
-                </row>
-            </header>
-            <group id="63">
-                <property name="groupName">TDProductLine</property>
-                <expression name="keyExpr" type="javascript">row["PRODUCTLINE"]</expression>
-                <expression name="bookmark" type="javascript">row["PRODUCTLINE"]</expression>
-                <structure name="toc">
-                    <expression name="expressionValue" type="javascript">row["PRODUCTLINE"]</expression>
-                </structure>
-                <property name="hideDetail">false</property>
-                <header>
-                    <row id="64">
-                        <cell id="65">
-                            <property name="colSpan">3</property>
-                            <property name="rowSpan">1</property>
-                            <expression name="bookmark" type="javascript">"bm-" + row["PRODUCTLINE"]</expression>
-                            <property name="tagType">TH</property>
-                            <property name="backgroundColor">#80FFFF</property>
-                            <data id="74">
-                                <property name="resultSetColumn">PRODUCTLINE</property>
-                            </data>
-                        </cell>
-                    </row>
-                </header>
-            </group>
-            <detail>
-                <row id="45">
-                    <cell id="46">
-                        <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",product"</expression>
-                        <data id="47">
-                            <property name="resultSetColumn">PRODUCTNAME</property>
-                        </data>
-                    </cell>
-                    <cell id="50">
-                        <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",descr"</expression>
-                        <data id="51">
-                            <property name="resultSetColumn">PRODUCTDESCRIPTION</property>
-                        </data>
-                    </cell>
-                    <cell id="52">
-                        <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",price"</expression>
-                        <data id="53">
-                            <property name="resultSetColumn">MSRP</property>
-                        </data>
-                    </cell>
-                </row>
-            </detail>
-        </table>
+            <column id="76"/>
+            <column id="77"/>
+            <column id="94"/>
+            <column id="78"/>
+            <row id="99">
+                <cell id="100">
+                    <property name="borderBottomStyle">solid</property>
+                    <property name="borderBottomWidth">thin</property>
+                    <property name="borderLeftStyle">solid</property>
+                    <property name="borderLeftWidth">thin</property>
+                    <property name="borderRightStyle">solid</property>
+                    <property name="borderRightWidth">thin</property>
+                    <property name="borderTopStyle">solid</property>
+                    <property name="borderTopWidth">thin</property>
+                    <property name="paddingTop">6pt</property>
+                    <property name="paddingLeft">6pt</property>
+                    <property name="paddingBottom">6pt</property>
+                    <property name="paddingRight">6pt</property>
+                    <label id="104">
+                        <text-property name="text">Product description</text-property>
+                    </label>
+                </cell>
+                <cell id="101">
+                    <property name="colSpan">3</property>
+                    <property name="rowSpan">1</property>
+                    <property name="borderBottomStyle">solid</property>
+                    <property name="borderBottomWidth">thin</property>
+                    <property name="borderLeftStyle">solid</property>
+                    <property name="borderLeftWidth">thin</property>
+                    <property name="borderRightStyle">solid</property>
+                    <property name="borderRightWidth">thin</property>
+                    <property name="borderTopStyle">solid</property>
+                    <property name="borderTopWidth">thin</property>
+                    <property name="paddingTop">6pt</property>
+                    <property name="paddingLeft">6pt</property>
+                    <property name="paddingBottom">6pt</property>
+                    <property name="paddingRight">6pt</property>
+                    <text-data id="105">
+                        <expression name="valueExpr">"&lt;h1>Super!&lt;/h1>&lt;p>This is some HTML including &lt;em>emphasized text&lt;/em> and &lt;strong>strong text&lt;/strong>.&lt;/p>"</expression>
+                        <property name="contentType">html</property>
+                    </text-data>
+                </cell>
+            </row>
+            <row id="79">
+                <cell id="80">
+                    <property name="borderBottomStyle">solid</property>
+                    <property name="borderBottomWidth">thin</property>
+                    <property name="borderLeftStyle">solid</property>
+                    <property name="borderLeftWidth">thin</property>
+                    <property name="borderRightStyle">solid</property>
+                    <property name="borderRightWidth">thin</property>
+                    <property name="borderTopStyle">solid</property>
+                    <property name="borderTopWidth">thin</property>
+                    <property name="paddingTop">6pt</property>
+                    <property name="paddingLeft">6pt</property>
+                    <property name="paddingBottom">6pt</property>
+                    <property name="paddingRight">6pt</property>
+                    <label id="95">
+                        <text-property name="text">Code</text-property>
+                    </label>
+                </cell>
+                <cell id="81">
+                    <property name="borderBottomStyle">solid</property>
+                    <property name="borderBottomWidth">thin</property>
+                    <property name="borderLeftStyle">solid</property>
+                    <property name="borderLeftWidth">thin</property>
+                    <property name="borderRightStyle">solid</property>
+                    <property name="borderRightWidth">thin</property>
+                    <property name="borderTopStyle">solid</property>
+                    <property name="borderTopWidth">thin</property>
+                    <property name="paddingTop">6pt</property>
+                    <property name="paddingLeft">6pt</property>
+                    <property name="paddingBottom">6pt</property>
+                    <property name="paddingRight">6pt</property>
+                    <data id="107">
+                        <property name="resultSetColumn">PRODUCTCODE</property>
+                    </data>
+                </cell>
+                <cell id="91">
+                    <property name="borderBottomStyle">solid</property>
+                    <property name="borderBottomWidth">thin</property>
+                    <property name="borderLeftStyle">solid</property>
+                    <property name="borderLeftWidth">thin</property>
+                    <property name="borderRightStyle">solid</property>
+                    <property name="borderRightWidth">thin</property>
+                    <property name="borderTopStyle">solid</property>
+                    <property name="borderTopWidth">thin</property>
+                    <property name="paddingTop">6pt</property>
+                    <property name="paddingLeft">6pt</property>
+                    <property name="paddingBottom">6pt</property>
+                    <property name="paddingRight">6pt</property>
+                    <label id="97">
+                        <text-property name="text">MSRP</text-property>
+                    </label>
+                </cell>
+                <cell id="82">
+                    <property name="borderBottomStyle">solid</property>
+                    <property name="borderBottomWidth">thin</property>
+                    <property name="borderLeftStyle">solid</property>
+                    <property name="borderLeftWidth">thin</property>
+                    <property name="borderRightStyle">solid</property>
+                    <property name="borderRightWidth">thin</property>
+                    <property name="borderTopStyle">solid</property>
+                    <property name="borderTopWidth">thin</property>
+                    <property name="paddingTop">6pt</property>
+                    <property name="paddingLeft">6pt</property>
+                    <property name="paddingBottom">6pt</property>
+                    <property name="paddingRight">6pt</property>
+                    <data id="106">
+                        <property name="resultSetColumn">MSRP</property>
+                    </data>
+                </cell>
+            </row>
+            <row id="83">
+                <cell id="84">
+                    <property name="borderBottomStyle">solid</property>
+                    <property name="borderBottomWidth">thin</property>
+                    <property name="borderLeftStyle">solid</property>
+                    <property name="borderLeftWidth">thin</property>
+                    <property name="borderRightStyle">solid</property>
+                    <property name="borderRightWidth">thin</property>
+                    <property name="borderTopStyle">solid</property>
+                    <property name="borderTopWidth">thin</property>
+                    <property name="paddingTop">6pt</property>
+                    <property name="paddingLeft">6pt</property>
+                    <property name="paddingBottom">6pt</property>
+                    <property name="paddingRight">6pt</property>
+                    <label id="96">
+                        <text-property name="text">Name</text-property>
+                    </label>
+                </cell>
+                <cell id="85">
+                    <property name="borderBottomStyle">solid</property>
+                    <property name="borderBottomWidth">thin</property>
+                    <property name="borderLeftStyle">solid</property>
+                    <property name="borderLeftWidth">thin</property>
+                    <property name="borderRightStyle">solid</property>
+                    <property name="borderRightWidth">thin</property>
+                    <property name="borderTopStyle">solid</property>
+                    <property name="borderTopWidth">thin</property>
+                    <property name="paddingTop">6pt</property>
+                    <property name="paddingLeft">6pt</property>
+                    <property name="paddingBottom">6pt</property>
+                    <property name="paddingRight">6pt</property>
+                    <data id="108">
+                        <property name="resultSetColumn">PRODUCTNAME</property>
+                    </data>
+                </cell>
+                <cell id="92">
+                    <property name="borderBottomStyle">solid</property>
+                    <property name="borderBottomWidth">thin</property>
+                    <property name="borderLeftStyle">solid</property>
+                    <property name="borderLeftWidth">thin</property>
+                    <property name="borderRightStyle">solid</property>
+                    <property name="borderRightWidth">thin</property>
+                    <property name="borderTopStyle">solid</property>
+                    <property name="borderTopWidth">thin</property>
+                    <property name="paddingTop">6pt</property>
+                    <property name="paddingLeft">6pt</property>
+                    <property name="paddingBottom">6pt</property>
+                    <property name="paddingRight">6pt</property>
+                    <label id="98">
+                        <text-property name="text">Scale</text-property>
+                    </label>
+                </cell>
+                <cell id="86">
+                    <property name="borderBottomStyle">solid</property>
+                    <property name="borderBottomWidth">thin</property>
+                    <property name="borderLeftStyle">solid</property>
+                    <property name="borderLeftWidth">thin</property>
+                    <property name="borderRightStyle">solid</property>
+                    <property name="borderRightWidth">thin</property>
+                    <property name="borderTopStyle">solid</property>
+                    <property name="borderTopWidth">thin</property>
+                    <property name="paddingTop">6pt</property>
+                    <property name="paddingLeft">6pt</property>
+                    <property name="paddingBottom">6pt</property>
+                    <property name="paddingRight">6pt</property>
+                    <data id="109">
+                        <property name="resultSetColumn">PRODUCTSCALE</property>
+                    </data>
+                </cell>
+            </row>
+        </grid>
     </body>
 </report>

--- a/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/headingsAndComplexTableHTML.rptdesign
+++ b/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/headingsAndComplexTableHTML.rptdesign
@@ -2,12 +2,12 @@
 <report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.26" id="1">
     <property name="author">Henning von Bargen</property>
     <property name="createdBy">Eclipse BIRT Designer Version 4.18.0.qualifier Build &lt;@BUILD@></property>
-    <text-property name="title">A table with a group header</text-property>
+    <text-property name="title">Das ist der Titel</text-property>
     <property name="units">in</property>
     <property name="iconFile">/templates/blank_report.gif</property>
     <property name="bidiLayoutOrientation">ltr</property>
     <property name="imageDPI">96</property>
-    <property name="locale">en_US</property>
+    <property name="locale">de_DE</property>
     <property name="pdfVersion">1.7</property>
     <property name="pdfConformance">PDF.A1A</property>
     <property name="pdfUAConformance">PDF.UA-1</property>
@@ -46,34 +46,10 @@
                     <text-property name="heading">PRODUCTNAME</text-property>
                 </structure>
                 <structure>
-                    <property name="columnName">PRODUCTLINE</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTLINE</text-property>
-                    <text-property name="heading">PRODUCTLINE</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">PRODUCTSCALE</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTSCALE</text-property>
-                    <text-property name="heading">PRODUCTSCALE</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">PRODUCTVENDOR</property>
-                    <property name="analysis">dimension</property>
-                    <text-property name="displayName">PRODUCTVENDOR</text-property>
-                    <text-property name="heading">PRODUCTVENDOR</text-property>
-                </structure>
-                <structure>
                     <property name="columnName">PRODUCTDESCRIPTION</property>
                     <property name="analysis">dimension</property>
                     <text-property name="displayName">PRODUCTDESCRIPTION</text-property>
                     <text-property name="heading">PRODUCTDESCRIPTION</text-property>
-                </structure>
-                <structure>
-                    <property name="columnName">QUANTITYINSTOCK</property>
-                    <property name="analysis">measure</property>
-                    <text-property name="displayName">QUANTITYINSTOCK</text-property>
-                    <text-property name="heading">QUANTITYINSTOCK</text-property>
                 </structure>
                 <structure>
                     <property name="columnName">BUYPRICE</property>
@@ -82,10 +58,16 @@
                     <text-property name="heading">BUYPRICE</text-property>
                 </structure>
                 <structure>
-                    <property name="columnName">MSRP</property>
-                    <property name="analysis">measure</property>
-                    <text-property name="displayName">MSRP</text-property>
-                    <text-property name="heading">MSRP</text-property>
+                    <property name="columnName">PRODUCTLINE</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">PRODUCTLINE</text-property>
+                    <text-property name="heading">PRODUCTLINE</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">HTMLDESCRIPTION</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">HTMLDESCRIPTION</text-property>
+                    <text-property name="heading">HTMLDESCRIPTION</text-property>
                 </structure>
             </list-property>
             <list-property name="parameters"/>
@@ -103,42 +85,27 @@
                     </structure>
                     <structure>
                         <property name="position">3</property>
-                        <property name="name">PRODUCTLINE</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">4</property>
-                        <property name="name">PRODUCTSCALE</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">5</property>
-                        <property name="name">PRODUCTVENDOR</property>
-                        <property name="dataType">string</property>
-                    </structure>
-                    <structure>
-                        <property name="position">6</property>
                         <property name="name">PRODUCTDESCRIPTION</property>
                         <property name="dataType">string</property>
                     </structure>
                     <structure>
-                        <property name="position">7</property>
-                        <property name="name">QUANTITYINSTOCK</property>
-                        <property name="dataType">integer</property>
-                    </structure>
-                    <structure>
-                        <property name="position">8</property>
+                        <property name="position">4</property>
                         <property name="name">BUYPRICE</property>
                         <property name="dataType">float</property>
                     </structure>
                     <structure>
-                        <property name="position">9</property>
-                        <property name="name">MSRP</property>
-                        <property name="dataType">float</property>
+                        <property name="position">5</property>
+                        <property name="name">PRODUCTLINE</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">6</property>
+                        <property name="name">HTMLDESCRIPTION</property>
+                        <property name="dataType">string</property>
                     </structure>
                 </list-property>
             </structure>
-            <property name="rowFetchLimit">6</property>
+            <property name="rowFetchLimit">50</property>
             <property name="dataSource">CM</property>
             <list-property name="resultSet">
                 <structure>
@@ -157,57 +124,42 @@
                 </structure>
                 <structure>
                     <property name="position">3</property>
-                    <property name="name">PRODUCTLINE</property>
-                    <property name="nativeName">PRODUCTLINE</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">4</property>
-                    <property name="name">PRODUCTSCALE</property>
-                    <property name="nativeName">PRODUCTSCALE</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">5</property>
-                    <property name="name">PRODUCTVENDOR</property>
-                    <property name="nativeName">PRODUCTVENDOR</property>
-                    <property name="dataType">string</property>
-                    <property name="nativeDataType">12</property>
-                </structure>
-                <structure>
-                    <property name="position">6</property>
                     <property name="name">PRODUCTDESCRIPTION</property>
                     <property name="nativeName">PRODUCTDESCRIPTION</property>
                     <property name="dataType">string</property>
                     <property name="nativeDataType">12</property>
                 </structure>
                 <structure>
-                    <property name="position">7</property>
-                    <property name="name">QUANTITYINSTOCK</property>
-                    <property name="nativeName">QUANTITYINSTOCK</property>
-                    <property name="dataType">integer</property>
-                    <property name="nativeDataType">4</property>
-                </structure>
-                <structure>
-                    <property name="position">8</property>
+                    <property name="position">4</property>
                     <property name="name">BUYPRICE</property>
                     <property name="nativeName">BUYPRICE</property>
                     <property name="dataType">float</property>
                     <property name="nativeDataType">8</property>
                 </structure>
                 <structure>
-                    <property name="position">9</property>
-                    <property name="name">MSRP</property>
-                    <property name="nativeName">MSRP</property>
-                    <property name="dataType">float</property>
-                    <property name="nativeDataType">8</property>
+                    <property name="position">5</property>
+                    <property name="name">PRODUCTLINE</property>
+                    <property name="nativeName">PRODUCTLINE</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">6</property>
+                    <property name="name">HTMLDESCRIPTION</property>
+                    <property name="nativeName">HTMLDESCRIPTION</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">2005</property>
                 </structure>
             </list-property>
-            <xml-property name="queryText"><![CDATA[select *
+            <xml-property name="queryText"><![CDATA[select products.productcode
+     , products.productname
+     , products.productdescription
+     , products.buyprice
+     , products.productline
+     , productlines.htmldescription
 from products
-order by productline, productname]]></xml-property>
+join productlines on (products.productline = productlines.productline)
+order by products.productline, products.productname]]></xml-property>
             <xml-property name="designerValues"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
 <model:DesignValues xmlns:design="http://www.eclipse.org/datatools/connectivity/oda/design" xmlns:model="http://www.eclipse.org/birt/report/model/adapter/odaModel">
   <Version>2.0</Version>
@@ -414,6 +366,22 @@ order by productline, productname]]></xml-property>
         <style name="report" id="6">
             <property name="fontFamily">"Arial"</property>
         </style>
+        <style name="h1" id="77">
+            <property name="fontSize">14pt</property>
+            <property name="marginTop">12pt</property>
+            <property name="marginBottom">6pt</property>
+        </style>
+        <style name="h2" id="82">
+            <property name="fontSize">12pt</property>
+            <property name="marginTop">12pt</property>
+            <property name="marginBottom">6pt</property>
+        </style>
+        <style name="h3" id="100">
+            <property name="fontSize">10pt</property>
+            <property name="fontWeight">bold</property>
+            <property name="marginTop">12pt</property>
+            <property name="marginBottom">6pt</property>
+        </style>
     </styles>
     <page-setup>
         <simple-master-page name="Simple MasterPage" id="2">
@@ -426,6 +394,35 @@ order by productline, productname]]></xml-property>
         </simple-master-page>
     </page-setup>
     <body>
+        <label name="chap1" id="76">
+            <property name="style">h1</property>
+            <text-property name="text">The First Chapter</text-property>
+            <property name="tagType">H1</property>
+        </label>
+        <label name="chap1-1" id="81">
+            <property name="style">h2</property>
+            <text-property name="text">1.1 Intro</text-property>
+            <property name="tagType">H2</property>
+        </label>
+        <label id="78">
+            <text-property name="text">Hey, wasn't that the title of the best album from "The Mission"?</text-property>
+        </label>
+        <label name="chap1-2" id="83">
+            <property name="style">h2</property>
+            <text-property name="text">1.2 Catalog</text-property>
+            <property name="tagType">H2</property>
+        </label>
+        <label id="99">
+            <text-property name="text">Here you find our product catalog. Have fun!</text-property>
+        </label>
+        <label name="chap1-2-1" id="98">
+            <property name="style">h3</property>
+            <text-property name="text">1.2.1 Catalog Table</text-property>
+            <property name="tagType">H3</property>
+        </label>
+        <label id="84">
+            <text-property name="text">We need a H3 header because the HTMLDESCRIPTION contains H4 headers without H3, H2, H1.</text-property>
+        </label>
         <table id="35">
             <property name="dataSet">Products</property>
             <list-property name="boundDataColumns">
@@ -448,13 +445,26 @@ order by productline, productname]]></xml-property>
                     <property name="dataType">string</property>
                 </structure>
                 <structure>
-                    <property name="name">MSRP</property>
-                    <text-property name="displayName">MSRP</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["MSRP"]</expression>
+                    <property name="name">PRODUCTCODE</property>
+                    <text-property name="displayName">PRODUCTCODE</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["PRODUCTCODE"]</expression>
+                    <property name="dataType">string</property>
+                </structure>
+                <structure>
+                    <property name="name">BUYPRICE</property>
+                    <text-property name="displayName">BUYPRICE</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["BUYPRICE"]</expression>
                     <property name="dataType">float</property>
+                </structure>
+                <structure>
+                    <property name="name">HTMLDESCRIPTION</property>
+                    <text-property name="displayName">HTMLDESCRIPTION</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["HTMLDESCRIPTION"]</expression>
+                    <property name="dataType">string</property>
                 </structure>
             </list-property>
             <property name="pageBreakInterval">9999</property>
+            <text-property name="caption">This is the table caption!</text-property>
             <column id="59"/>
             <column id="61"/>
             <column id="62"/>
@@ -497,15 +507,17 @@ order by productline, productname]]></xml-property>
                             <expression name="bookmark" type="javascript">"bm-" + row["PRODUCTLINE"]</expression>
                             <property name="tagType">TH</property>
                             <property name="backgroundColor">#80FFFF</property>
-                            <data id="74">
-                                <property name="resultSetColumn">PRODUCTLINE</property>
-                            </data>
+                            <text-data id="96">
+                                <expression name="valueExpr">row["HTMLDESCRIPTION"]</expression>
+                                <property name="contentType">html</property>
+                            </text-data>
                         </cell>
                     </row>
                 </header>
             </group>
             <detail>
                 <row id="45">
+                    <property name="pageBreakInside">auto</property>
                     <cell id="46">
                         <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",product"</expression>
                         <data id="47">
@@ -520,12 +532,38 @@ order by productline, productname]]></xml-property>
                     </cell>
                     <cell id="52">
                         <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",price"</expression>
-                        <data id="53">
-                            <property name="resultSetColumn">MSRP</property>
+                        <data id="97">
+                            <property name="resultSetColumn">BUYPRICE</property>
                         </data>
                     </cell>
                 </row>
             </detail>
         </table>
+        <label id="75">
+            <property name="marginTop">12pt</property>
+            <text-property name="text">This is a label after the table</text-property>
+        </label>
+        <label name="chap2" id="79">
+            <property name="style">h1</property>
+            <text-property name="text">The Next Chapter</text-property>
+            <property name="tagType">H1</property>
+        </label>
+        <label id="80">
+            <text-property name="text">Lorem ipsum dolor sit amet</text-property>
+        </label>
+        <text-data id="86">
+            <expression name="valueExpr">'&lt;p>This is some HTML including &lt;u>underlined text&lt;/u>.&lt;/p>'</expression>
+            <property name="contentType">html</property>
+        </text-data>
+        <text-data id="101">
+            <list-property name="visibility">
+                <structure>
+                    <property name="format">all</property>
+                    <expression name="valueExpr" type="javascript">true</expression>
+                </structure>
+            </list-property>
+            <expression name="valueExpr">'&lt;p>This is some more HTML including a hyperlink to &lt;a href="https://github.com/eclipse-birt/birt">the BIRT project page &lt;/a> on GitHub.&lt;/p>'</expression>
+            <property name="contentType">html</property>
+        </text-data>
     </body>
 </report>

--- a/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/list.rptdesign
+++ b/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/list.rptdesign
@@ -2,12 +2,12 @@
 <report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.26" id="1">
     <property name="author">Henning von Bargen</property>
     <property name="createdBy">Eclipse BIRT Designer Version 4.18.0.qualifier Build &lt;@BUILD@></property>
-    <text-property name="title">A table with a group header</text-property>
+    <text-property name="title">Das ist der Titel</text-property>
     <property name="units">in</property>
     <property name="iconFile">/templates/blank_report.gif</property>
     <property name="bidiLayoutOrientation">ltr</property>
     <property name="imageDPI">96</property>
-    <property name="locale">en_US</property>
+    <property name="locale">de_DE</property>
     <property name="pdfVersion">1.7</property>
     <property name="pdfConformance">PDF.A1A</property>
     <property name="pdfUAConformance">PDF.UA-1</property>
@@ -138,7 +138,7 @@
                     </structure>
                 </list-property>
             </structure>
-            <property name="rowFetchLimit">6</property>
+            <property name="rowFetchLimit">20</property>
             <property name="dataSource">CM</property>
             <list-property name="resultSet">
                 <structure>
@@ -417,7 +417,9 @@ order by productline, productname]]></xml-property>
     </styles>
     <page-setup>
         <simple-master-page name="Simple MasterPage" id="2">
-            <property name="type">a4</property>
+            <property name="type">custom</property>
+            <property name="height">60mm</property>
+            <property name="width">210mm</property>
             <page-header>
                 <label id="7">
                     <text-property name="text">Das ist ein Label im Header der MasterPage</text-property>
@@ -426,7 +428,7 @@ order by productline, productname]]></xml-property>
         </simple-master-page>
     </page-setup>
     <body>
-        <table id="35">
+        <list id="75">
             <property name="dataSet">Products</property>
             <list-property name="boundDataColumns">
                 <structure>
@@ -436,96 +438,22 @@ order by productline, productname]]></xml-property>
                     <property name="dataType">string</property>
                 </structure>
                 <structure>
-                    <property name="name">PRODUCTLINE</property>
-                    <text-property name="displayName">PRODUCTLINE</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["PRODUCTLINE"]</expression>
+                    <property name="name">Productname</property>
+                    <expression name="expression" type="javascript">row["PRODUCTNAME"]</expression>
                     <property name="dataType">string</property>
-                </structure>
-                <structure>
-                    <property name="name">PRODUCTDESCRIPTION</property>
-                    <text-property name="displayName">PRODUCTDESCRIPTION</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["PRODUCTDESCRIPTION"]</expression>
-                    <property name="dataType">string</property>
-                </structure>
-                <structure>
-                    <property name="name">MSRP</property>
-                    <text-property name="displayName">MSRP</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["MSRP"]</expression>
-                    <property name="dataType">float</property>
+                    <property name="allowExport">true</property>
                 </structure>
             </list-property>
-            <property name="pageBreakInterval">9999</property>
-            <column id="59"/>
-            <column id="61"/>
-            <column id="62"/>
             <header>
-                <row id="36">
-                    <property name="backgroundColor">#80FF00</property>
-                    <cell id="37">
-                        <expression name="bookmark" type="javascript">"product"</expression>
-                        <label id="38">
-                            <text-property name="text">Product Name</text-property>
-                        </label>
-                    </cell>
-                    <cell id="41">
-                        <expression name="bookmark" type="javascript">"descr"</expression>
-                        <label id="42">
-                            <text-property name="text">Description</text-property>
-                        </label>
-                    </cell>
-                    <cell id="43">
-                        <expression name="bookmark" type="javascript">"price"</expression>
-                        <label id="44">
-                            <text-property name="text">Price</text-property>
-                        </label>
-                    </cell>
-                </row>
+                <label id="77">
+                    <text-property name="text">Kopfzeile</text-property>
+                </label>
             </header>
-            <group id="63">
-                <property name="groupName">TDProductLine</property>
-                <expression name="keyExpr" type="javascript">row["PRODUCTLINE"]</expression>
-                <expression name="bookmark" type="javascript">row["PRODUCTLINE"]</expression>
-                <structure name="toc">
-                    <expression name="expressionValue" type="javascript">row["PRODUCTLINE"]</expression>
-                </structure>
-                <property name="hideDetail">false</property>
-                <header>
-                    <row id="64">
-                        <cell id="65">
-                            <property name="colSpan">3</property>
-                            <property name="rowSpan">1</property>
-                            <expression name="bookmark" type="javascript">"bm-" + row["PRODUCTLINE"]</expression>
-                            <property name="tagType">TH</property>
-                            <property name="backgroundColor">#80FFFF</property>
-                            <data id="74">
-                                <property name="resultSetColumn">PRODUCTLINE</property>
-                            </data>
-                        </cell>
-                    </row>
-                </header>
-            </group>
             <detail>
-                <row id="45">
-                    <cell id="46">
-                        <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",product"</expression>
-                        <data id="47">
-                            <property name="resultSetColumn">PRODUCTNAME</property>
-                        </data>
-                    </cell>
-                    <cell id="50">
-                        <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",descr"</expression>
-                        <data id="51">
-                            <property name="resultSetColumn">PRODUCTDESCRIPTION</property>
-                        </data>
-                    </cell>
-                    <cell id="52">
-                        <expression name="headers" type="javascript">"bm-" + row["PRODUCTLINE"] + ",price"</expression>
-                        <data id="53">
-                            <property name="resultSetColumn">MSRP</property>
-                        </data>
-                    </cell>
-                </row>
+                <data id="79">
+                    <property name="resultSetColumn">Productname</property>
+                </data>
             </detail>
-        </table>
+        </list>
     </body>
 </report>

--- a/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/pageNumbering.rptdesign
+++ b/UI/org.eclipse.birt.report.designer.samplereports/samplereports/Reporting Feature Examples/Accessibility/pageNumbering.rptdesign
@@ -1,0 +1,410 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.26" id="1">
+    <property name="author">Henning von Bargen</property>
+    <property name="createdBy">Eclipse BIRT Designer Version 4.18.0.qualifier Build &lt;@BUILD@></property>
+    <text-property name="title">This is the document title</text-property>
+    <property name="units">in</property>
+    <property name="iconFile">/templates/blank_report.gif</property>
+    <property name="bidiLayoutOrientation">ltr</property>
+    <property name="imageDPI">96</property>
+    <property name="locale">en_US</property>
+    <property name="pdfVersion">1.7</property>
+    <property name="pdfConformance">PDF.A3A</property>
+    <property name="pdfUAConformance">PDF.UA-1</property>
+    <property name="pdfaFontCidEmbed">false</property>
+    <property name="pdfaDocumentTitleEmbed">true</property>
+    <data-sources>
+        <oda-data-source extensionID="org.eclipse.birt.report.data.oda.jdbc" name="CM" id="14">
+            <list-property name="privateDriverProperties">
+                <ex-property>
+                    <name>contentBidiFormatStr</name>
+                    <value>ILYNN</value>
+                </ex-property>
+                <ex-property>
+                    <name>metadataBidiFormatStr</name>
+                    <value>ILYNN</value>
+                </ex-property>
+            </list-property>
+            <property name="odaDriverClass">org.eclipse.birt.report.data.oda.sampledb.Driver</property>
+            <property name="odaURL">jdbc:classicmodels:sampledb</property>
+            <property name="odaUser">ClassicModels</property>
+        </oda-data-source>
+    </data-sources>
+    <data-sets>
+        <oda-data-set extensionID="org.eclipse.birt.report.data.oda.jdbc.JdbcSelectDataSet" name="Productlines" id="15">
+            <property name="nullsOrdering">nulls lowest</property>
+            <list-property name="columnHints">
+                <structure>
+                    <property name="columnName">PRODUCTLINE</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">PRODUCTLINE</text-property>
+                    <text-property name="heading">PRODUCTLINE</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">TEXTDESCRIPTION</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">TEXTDESCRIPTION</text-property>
+                    <text-property name="heading">TEXTDESCRIPTION</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">HTMLDESCRIPTION</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">HTMLDESCRIPTION</text-property>
+                    <text-property name="heading">HTMLDESCRIPTION</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">IMAGE</property>
+                    <property name="analysis">attribute</property>
+                    <text-property name="displayName">IMAGE</text-property>
+                    <text-property name="heading">IMAGE</text-property>
+                </structure>
+            </list-property>
+            <structure name="cachedMetaData">
+                <list-property name="resultSet">
+                    <structure>
+                        <property name="position">1</property>
+                        <property name="name">PRODUCTLINE</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">2</property>
+                        <property name="name">TEXTDESCRIPTION</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">3</property>
+                        <property name="name">HTMLDESCRIPTION</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">4</property>
+                        <property name="name">IMAGE</property>
+                        <property name="dataType">blob</property>
+                    </structure>
+                </list-property>
+            </structure>
+            <property name="rowFetchLimit">20</property>
+            <property name="dataSource">CM</property>
+            <list-property name="resultSet">
+                <structure>
+                    <property name="position">1</property>
+                    <property name="name">PRODUCTLINE</property>
+                    <property name="nativeName">PRODUCTLINE</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">2</property>
+                    <property name="name">TEXTDESCRIPTION</property>
+                    <property name="nativeName">TEXTDESCRIPTION</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">3</property>
+                    <property name="name">HTMLDESCRIPTION</property>
+                    <property name="nativeName">HTMLDESCRIPTION</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">2005</property>
+                </structure>
+                <structure>
+                    <property name="position">4</property>
+                    <property name="name">IMAGE</property>
+                    <property name="nativeName">IMAGE</property>
+                    <property name="dataType">blob</property>
+                    <property name="nativeDataType">2004</property>
+                </structure>
+            </list-property>
+            <xml-property name="queryText"><![CDATA[select *
+from productlines
+order by 1]]></xml-property>
+            <xml-property name="designerValues"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+<model:DesignValues xmlns:design="http://www.eclipse.org/datatools/connectivity/oda/design" xmlns:model="http://www.eclipse.org/birt/report/model/adapter/odaModel">
+  <Version>2.0</Version>
+  <design:ResultSets derivedMetaData="true">
+    <design:resultSetDefinitions>
+      <design:resultSetColumns>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>PRODUCTLINE</design:name>
+              <design:position>1</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>12</design:nativeDataTypeCode>
+            <design:precision>50</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>PRODUCTLINE</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>PRODUCTLINE</design:label>
+            <design:formattingHints>
+              <design:displaySize>50</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>TEXTDESCRIPTION</design:name>
+              <design:position>2</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>12</design:nativeDataTypeCode>
+            <design:precision>4000</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>TEXTDESCRIPTION</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>TEXTDESCRIPTION</design:label>
+            <design:formattingHints>
+              <design:displaySize>4000</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>HTMLDESCRIPTION</design:name>
+              <design:position>3</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>2005</design:nativeDataTypeCode>
+            <design:precision>2147483647</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>HTMLDESCRIPTION</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>HTMLDESCRIPTION</design:label>
+            <design:formattingHints>
+              <design:displaySize>2147483647</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>IMAGE</design:name>
+              <design:position>4</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>2004</design:nativeDataTypeCode>
+            <design:precision>2147483647</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>IMAGE</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>IMAGE</design:label>
+            <design:formattingHints>
+              <design:displaySize>2147483647</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+      </design:resultSetColumns>
+      <design:criteria/>
+    </design:resultSetDefinitions>
+  </design:ResultSets>
+</model:DesignValues>]]></xml-property>
+        </oda-data-set>
+    </data-sets>
+    <styles>
+        <style name="report" id="6">
+            <property name="fontFamily">"Arial"</property>
+        </style>
+    </styles>
+    <page-setup>
+        <simple-master-page name="Simple MasterPage" id="2">
+            <property name="type">a4</property>
+            <page-header>
+                <label id="7">
+                    <text-property name="text">This is a label in the page header.</text-property>
+                </label>
+            </page-header>
+            <page-footer>
+                <grid id="34">
+                    <column id="35"/>
+                    <row id="36">
+                        <cell id="37">
+                            <grid id="38">
+                                <column id="39"/>
+                                <column id="40"/>
+                                <column id="41"/>
+                                <row id="42">
+                                    <cell id="43">
+                                        <text id="46">
+                                            <property name="display">inline</property>
+                                            <property name="contentType">plain</property>
+                                            <text-property name="content"><![CDATA[Page ]]></text-property>
+                                        </text>
+                                        <auto-text id="44">
+                                            <property name="display">inline</property>
+                                            <property name="type">page-number</property>
+                                        </auto-text>
+                                        <text id="49">
+                                            <property name="display">inline</property>
+                                            <property name="contentType">plain</property>
+                                            <text-property name="content"><![CDATA[/]]></text-property>
+                                        </text>
+                                        <auto-text id="48">
+                                            <property name="display">inline</property>
+                                            <property name="type">total-page</property>
+                                        </auto-text>
+                                    </cell>
+                                    <cell id="45"/>
+                                    <cell id="47"/>
+                                </row>
+                            </grid>
+                        </cell>
+                    </row>
+                </grid>
+            </page-footer>
+        </simple-master-page>
+    </page-setup>
+    <body>
+        <label id="50">
+            <property name="fontSize">12pt</property>
+            <property name="fontWeight">bold</property>
+            <structure name="toc">
+                <expression name="expressionValue" type="javascript">"Heading at level 1"</expression>
+            </structure>
+            <text-property name="text">This is a heading at level one.</text-property>
+            <property name="tagType">H1</property>
+        </label>
+        <label id="51">
+            <property name="fontWeight">bold</property>
+            <structure name="toc">
+                <expression name="expressionValue" type="javascript">"Heading at level 2"</expression>
+            </structure>
+            <text-property name="text">This is a heading at level two.</text-property>
+            <property name="tagType">H2</property>
+        </label>
+        <label id="53">
+            <property name="fontWeight">normal</property>
+            <property name="fontStyle">italic</property>
+            <structure name="toc">
+                <expression name="expressionValue" type="javascript">"Heading at level 3"</expression>
+            </structure>
+            <text-property name="text">This is a heading at level three</text-property>
+            <property name="tagType">H3</property>
+        </label>
+        <label id="52">
+            <property name="fontWeight">normal</property>
+            <structure name="toc"/>
+            <text-property name="text">Please note that the table contains headings at level four, thus we need these two headings to get a correct structure.</text-property>
+            <property name="tagType">P</property>
+        </label>
+        <table id="16">
+            <property name="dataSet">Productlines</property>
+            <list-property name="boundDataColumns">
+                <structure>
+                    <property name="name">PRODUCTLINE</property>
+                    <text-property name="displayName">PRODUCTLINE</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["PRODUCTLINE"]</expression>
+                    <property name="dataType">string</property>
+                </structure>
+                <structure>
+                    <property name="name">HTMLDESCRIPTION</property>
+                    <text-property name="displayName">HTMLDESCRIPTION</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["HTMLDESCRIPTION"]</expression>
+                    <property name="dataType">string</property>
+                </structure>
+            </list-property>
+            <text-property name="caption">This is the table caption</text-property>
+            <column id="30">
+                <property name="width">20mm</property>
+            </column>
+            <column id="31"/>
+            <header>
+                <row id="17">
+                    <cell id="18">
+                        <property name="scope">col</property>
+                        <property name="borderBottomStyle">solid</property>
+                        <property name="borderBottomWidth">thin</property>
+                        <property name="borderLeftStyle">solid</property>
+                        <property name="borderLeftWidth">thin</property>
+                        <property name="borderRightStyle">solid</property>
+                        <property name="borderRightWidth">thin</property>
+                        <property name="borderTopStyle">solid</property>
+                        <property name="borderTopWidth">thin</property>
+                        <label id="19">
+                            <text-property name="text">PRODUCTLINE</text-property>
+                        </label>
+                    </cell>
+                    <cell id="20">
+                        <property name="scope">col</property>
+                        <property name="borderBottomStyle">solid</property>
+                        <property name="borderBottomWidth">thin</property>
+                        <property name="borderLeftStyle">solid</property>
+                        <property name="borderLeftWidth">thin</property>
+                        <property name="borderRightStyle">solid</property>
+                        <property name="borderRightWidth">thin</property>
+                        <property name="borderTopStyle">solid</property>
+                        <property name="borderTopWidth">thin</property>
+                        <label id="21">
+                            <text-property name="text">HTMLDESCRIPTION</text-property>
+                        </label>
+                    </cell>
+                </row>
+            </header>
+            <detail>
+                <row id="22">
+                    <cell id="23">
+                        <property name="borderBottomStyle">solid</property>
+                        <property name="borderBottomWidth">thin</property>
+                        <property name="borderLeftStyle">solid</property>
+                        <property name="borderLeftWidth">thin</property>
+                        <property name="borderRightStyle">solid</property>
+                        <property name="borderRightWidth">thin</property>
+                        <property name="borderTopStyle">solid</property>
+                        <property name="borderTopWidth">thin</property>
+                        <data id="24">
+                            <property name="resultSetColumn">PRODUCTLINE</property>
+                        </data>
+                    </cell>
+                    <cell id="25">
+                        <property name="borderBottomStyle">solid</property>
+                        <property name="borderBottomWidth">thin</property>
+                        <property name="borderLeftStyle">solid</property>
+                        <property name="borderLeftWidth">thin</property>
+                        <property name="borderRightStyle">solid</property>
+                        <property name="borderRightWidth">thin</property>
+                        <property name="borderTopStyle">solid</property>
+                        <property name="borderTopWidth">thin</property>
+                        <text-data id="33">
+                            <expression name="valueExpr">row["HTMLDESCRIPTION"]</expression>
+                            <property name="contentType">html</property>
+                        </text-data>
+                    </cell>
+                </row>
+            </detail>
+            <footer>
+                <row id="27">
+                    <cell id="28">
+                        <property name="colSpan">2</property>
+                        <property name="rowSpan">1</property>
+                        <property name="backgroundColor">yellow</property>
+                        <property name="borderBottomStyle">solid</property>
+                        <property name="borderBottomWidth">thin</property>
+                        <property name="borderLeftStyle">solid</property>
+                        <property name="borderLeftWidth">thin</property>
+                        <property name="borderRightStyle">solid</property>
+                        <property name="borderRightWidth">thin</property>
+                        <property name="borderTopStyle">solid</property>
+                        <property name="borderTopWidth">thin</property>
+                        <label id="32">
+                            <text-property name="text">This is the table footer.</text-property>
+                        </label>
+                    </cell>
+                </row>
+            </footer>
+        </table>
+    </body>
+</report>

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPage.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPage.java
@@ -233,16 +233,16 @@ public class PDFPage extends AbstractPage {
 			float height, float width, String helpText, Map params) throws Exception {
 
 		if (isTagged && artifactDepth == 0) {
-			pageDevice.structureCurrentLeaf.put(PdfNames.ALT, new PdfString(helpText));
+			pageDevice.structureCurrentNode.put(PdfNames.ALT, new PdfString(helpText));
 
-			PdfDictionary attributes = pageDevice.structureCurrentLeaf.getAsDict(PdfName.A);
+			PdfDictionary attributes = pageDevice.structureCurrentNode.getAsDict(PdfName.A);
 			if (attributes == null) {
 				attributes = new PdfDictionary();
-				pageDevice.structureCurrentLeaf.put(PdfName.A, attributes);
+				pageDevice.structureCurrentNode.put(PdfName.A, attributes);
 			}
 			attributes.put(PdfName.BBOX, new PdfRectangle(imageX, imageY, width, height));
 
-			contentByte.beginMarkedContentSequence(pageDevice.structureCurrentLeaf);
+			contentByte.beginMarkedContentSequence(pageDevice.structureCurrentNode);
 		}
 
 		// Cached Image
@@ -556,7 +556,7 @@ public class PDFPage extends AbstractPage {
 		contentByte.beginText();
 
 		if (isTagged && artifactDepth == 0) {
-			contentByte.beginMarkedContentSequence(pageDevice.structureCurrentLeaf);
+			contentByte.beginMarkedContentSequence(pageDevice.structureCurrentNode);
 		}
 
 		if (null != color && !Color.BLACK.equals(color)) {

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPage.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPage.java
@@ -425,7 +425,16 @@ public class PDFPage extends AbstractPage {
 			PdfContentByte tempCB = this.contentByte;
 			this.containerHeight = template.getHeight();
 			this.contentByte = template;
+			int artifactDepthOld = artifactDepth;
+			if (artifactDepthOld == 0) {
+				PdfDictionary properties = new PdfDictionary();
+				properties.put(PdfNames.TYPE, PdfNames.PAGINATION);
+				beginArtifact();
+			}
 			drawText(text, textX, textY, width, height, textInfo);
+			if (artifactDepthOld == 0) {
+				endArtifact();
+			}
 			this.contentByte = tempCB;
 			this.containerHeight = pageHeight;
 		}

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPageDevice.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPageDevice.java
@@ -153,7 +153,7 @@ public class PDFPageDevice implements IPageDevice {
 	// The StructureTree defines the logical structure of the content.
 	PdfStructureTreeRoot structureRoot = null;
 	PdfStructureElement structureDocument = null;
-	PdfStructureElement structureCurrentLeaf = null;
+	PdfStructureElement structureCurrentNode = null;
 
 	protected IReportContext context;
 
@@ -416,7 +416,7 @@ public class PDFPageDevice implements IPageDevice {
 
 		structureRoot = writer.getStructureTreeRoot();
 		structureDocument = new PdfStructureElement(structureRoot, new PdfName("Document"));
-		structureCurrentLeaf = structureDocument;
+		structureCurrentNode = structureDocument;
 
 	}
 
@@ -855,6 +855,7 @@ public class PDFPageDevice implements IPageDevice {
 		} else {
 			userPdfConformance = (String) getReportDesignConfiguration(this.report, PDFPageDevice.PDF_CONFORMANCE);
 		}
+
 		switch (userPdfConformance) {
 		case PDFPageDevice.PDF_CONFORMANCE_X32002:
 			this.pdfConformance = PdfWriter.PDFX32002;
@@ -869,27 +870,27 @@ public class PDFPageDevice implements IPageDevice {
 			this.isPdfAFormat = true;
 			break;
 		case PDFPageDevice.PDF_CONFORMANCE_A2A:
-			this.pdfConformance = PDFA2A;
+			this.pdfConformance = PDFPageDevice.PDFA2A;
 			this.isPdfAFormat = true;
 			break;
 		case PDFPageDevice.PDF_CONFORMANCE_A2B:
-			this.pdfConformance = PDFA2B;
+			this.pdfConformance = PDFPageDevice.PDFA2B;
 			this.isPdfAFormat = true;
 			break;
 		case PDFPageDevice.PDF_CONFORMANCE_A3A:
-			this.pdfConformance = PDFA3A;
+			this.pdfConformance = PDFPageDevice.PDFA3A;
 			this.isPdfAFormat = true;
 			break;
 		case PDFPageDevice.PDF_CONFORMANCE_A3B:
-			this.pdfConformance = PDFA3B;
+			this.pdfConformance = PDFPageDevice.PDFA3B;
 			this.isPdfAFormat = true;
 			break;
 		case PDFPageDevice.PDF_CONFORMANCE_A3U:
-			this.pdfConformance = PDFA3U;
+			this.pdfConformance = PDFPageDevice.PDFA3U;
 			this.isPdfAFormat = true;
 			break;
 		case PDFPageDevice.PDF_CONFORMANCE_A4F:
-			this.pdfConformance = PDFA4F;
+			this.pdfConformance = PDFPageDevice.PDFA4F;
 			this.isPdfAFormat = true;
 			break;
 		default:
@@ -928,8 +929,8 @@ public class PDFPageDevice implements IPageDevice {
 		}
 	}
 
-	// FIXME THis is a workaround for the fact that OpenPDF does not support PDF/A-2
-	// or newer
+	// FIXME The existence of these constants is a workaround for the fact that
+	// OpenPDF does not yet support PDF/A-2 or newer.
 	private static final int PDFA2A = 5;
 	private static final int PDFA2B = 6;
 	private static final int PDFA3A = 7;
@@ -950,17 +951,17 @@ public class PDFPageDevice implements IPageDevice {
 			return PDFPageDevice.PDF_CONFORMANCE_A1A;
 		case PdfWriter.PDFA1B:
 			return PDFPageDevice.PDF_CONFORMANCE_A1B;
-		case PDFA2A:
+		case PDFPageDevice.PDFA2A:
 			return PDFPageDevice.PDF_CONFORMANCE_A2A;
-		case PDFA2B:
+		case PDFPageDevice.PDFA2B:
 			return PDFPageDevice.PDF_CONFORMANCE_A2B;
-		case PDFA3A:
+		case PDFPageDevice.PDFA3A:
 			return PDFPageDevice.PDF_CONFORMANCE_A3A;
-		case PDFA3B:
+		case PDFPageDevice.PDFA3B:
 			return PDFPageDevice.PDF_CONFORMANCE_A3B;
-		case PDFA3U:
+		case PDFPageDevice.PDFA3U:
 			return PDFPageDevice.PDF_CONFORMANCE_A3U;
-		case PDFA4F:
+		case PDFPageDevice.PDFA4F:
 			return PDFPageDevice.PDF_CONFORMANCE_A4F;
 		default:
 			return PDFPageDevice.PDF_CONFORMANCE_STANDARD;
@@ -985,11 +986,14 @@ public class PDFPageDevice implements IPageDevice {
 		return this.isPdfUAFormat;
 	}
 
+	/**
+	 * PDF XMP schema for declaring that the PDF is PDF/UA conforming.
+	 *
+	 * @since 4.18
+	 *
+	 */
 	private static class PDFUASchema extends XmpSchema {
 
-		/**
-		 *
-		 */
 		private static final long serialVersionUID = -6990512370284803429L;
 
 		public PDFUASchema() {
@@ -1007,11 +1011,17 @@ public class PDFPageDevice implements IPageDevice {
 
 	}
 
+	/**
+	 * PDF XMP schema for declaring that the PDF is PDF/A conforming.
+	 *
+	 * Since the document can be PDF/UA conforming at the same time, the PDF/A
+	 * specification requires that this is other schema is also described here.
+	 *
+	 * @since 4.18
+	 *
+	 */
 	private static class PDFAExtensionSchema extends XmpSchema {
 
-		/**
-		 *
-		 */
 		private static final long serialVersionUID = 6654512771721220538L;
 
 		public PDFAExtensionSchema() {
@@ -1049,8 +1059,10 @@ public class PDFPageDevice implements IPageDevice {
 	}
 
 	/**
-	 * Create the XML for the XMPMetadata. We use the same method from PdfWriter as
-	 * a template and add what is neeeded for PDF/UA.
+	 * Create the XML for the XMPMetadata.
+	 *
+	 * We use the same method from {@link PdfWriter} as a template and add what is
+	 * needed for PDF/UA.
 	 *
 	 * @return an XmpMetadata byte array
 	 */
@@ -1177,7 +1189,7 @@ public class PDFPageDevice implements IPageDevice {
 	}
 
 	/**
-	 * Set the PDF icc color profile and the XMP meta data
+	 * Set the PDF ICC color profile and the XMP meta data
 	 */
 	private void setPdfIccXmp() {
 
@@ -1356,8 +1368,8 @@ public class PDFPageDevice implements IPageDevice {
 	/**
 	 * Open a tag in the tag tree structure.
 	 *
-	 * Basically this means: Create a new child node for structureCurrentLeaf and
-	 * let structureCurrentLeaf point to this child node. But several edge cases
+	 * Basically this means: Create a new child node for structureCurrentNode and
+	 * let structureCurrentNode point to this child node. But several edge cases
 	 * need special handling. For example, when we are in an artifact, we don't want
 	 * to open a new tag. And containers need special handling for page-breaking to
 	 * avoid the creation of unnecessary tags, e.g. a table that spans two pages
@@ -1408,26 +1420,27 @@ public class PDFPageDevice implements IPageDevice {
 						if (PdfTag.TR.equals(tagType)) {
 							beforeOpenTableSectionTag(container);
 						}
-						structureCurrentLeaf = new PdfStructureElement(structureCurrentLeaf, new PdfName(tagType));
+						structureCurrentNode = new PdfStructureElement(structureCurrentNode, new PdfName(tagType));
 						try {
-							container.setStructureElement(structureCurrentLeaf);
+							container.setStructureElement(structureCurrentNode);
 						} catch (BirtException be) {
 							be.printStackTrace();
-							structureCurrentLeaf = new PdfStructureElement(structureCurrentLeaf, new PdfName(tagType));
+							structureCurrentNode = new PdfStructureElement(structureCurrentNode, new PdfName(tagType));
 						}
 					} else {
-						structureCurrentLeaf = container.getFirstPart().getStructureElement();
-						PdfName restored = structureCurrentLeaf.getAsName(PdfName.S);
+						structureCurrentNode = container.getFirstPart().getStructureElement();
+						PdfName restored = structureCurrentNode.getAsName(PdfName.S);
 						if (PdfName.TABLE.equals(restored)) {
 							// Also restore the table section, e.g. TBody.
-							PdfArray kids = structureCurrentLeaf.getAsArray(PdfName.K);
-							if (kids != null && kids.size() > 0) {
-								structureCurrentLeaf = (PdfStructureElement) kids.getAsDict(kids.size() - 1);
+							PdfArray children = structureCurrentNode.getAsArray(PdfName.K); // K means "kids" in this
+																							// context
+							if (children != null && children.size() > 0) {
+								structureCurrentNode = (PdfStructureElement) children.getAsDict(children.size() - 1);
 							}
 						}
 					}
 				} else {
-					structureCurrentLeaf = new PdfStructureElement(structureCurrentLeaf, new PdfName(tagType));
+					structureCurrentNode = new PdfStructureElement(structureCurrentNode, new PdfName(tagType));
 				}
 				if (PdfTag.FIGURE.equals(tagType)) {
 					addFigureAttributes();
@@ -1449,7 +1462,7 @@ public class PDFPageDevice implements IPageDevice {
 	 * @param row the RowArea.
 	 */
 	private void beforeOpenTableSectionTag(final ContainerArea row) {
-		PdfName currentTag = structureCurrentLeaf.getAsName(PdfName.S);
+		PdfName currentTag = structureCurrentNode.getAsName(PdfName.S);
 		RowContent rowContent = (RowContent) row.getContent();
 		PdfName inject = null;
 		boolean closeSection = false;
@@ -1475,10 +1488,10 @@ public class PDFPageDevice implements IPageDevice {
 			}
 		}
 		if (closeSection) {
-			structureCurrentLeaf = (PdfStructureElement) structureCurrentLeaf.getParent();
+			structureCurrentNode = (PdfStructureElement) structureCurrentNode.getParent();
 		}
 		if (inject != null) {
-			structureCurrentLeaf = new PdfStructureElement(structureCurrentLeaf, inject);
+			structureCurrentNode = new PdfStructureElement(structureCurrentNode, inject);
 		}
 	}
 
@@ -1495,16 +1508,16 @@ public class PDFPageDevice implements IPageDevice {
 			String scope = ((CellContent) (cellArea.getContent())).getScope();
 			String bookmark = cellArea.getBookmark();
 			if (bookmark != null) {
-				structureCurrentLeaf.put(PdfName.ID, new PdfString(bookmark));
+				structureCurrentNode.put(PdfName.ID, new PdfString(bookmark));
 			}
 
 			String headers = ((CellContent) (cellArea.getContent())).getHeaders();
 			if (rowspan != 1 || colspan != 1 || scope != null || headers != null) {
-				PdfDictionary attributes = structureCurrentLeaf.getAsDict(PdfName.A);
+				PdfDictionary attributes = structureCurrentNode.getAsDict(PdfName.A);
 				if (attributes == null) {
 					attributes = new PdfDictionary();
 					attributes.put(PdfName.O, PdfName.TABLE);
-					structureCurrentLeaf.put(PdfName.A, attributes);
+					structureCurrentNode.put(PdfName.A, attributes);
 				}
 				if (rowspan != 1) {
 					attributes.put(PdfNames.ROWSPAN, new PdfNumber(rowspan));
@@ -1528,11 +1541,11 @@ public class PDFPageDevice implements IPageDevice {
 	 * Top-Level figure elements must have a placement attribute.
 	 */
 	private void addFigureAttributes() {
-		if (PdfName.DOCUMENT.equals(structureCurrentLeaf.getParent().get(PdfName.S))) {
-			PdfDictionary attributes = structureCurrentLeaf.getAsDict(PdfName.A);
+		if (PdfName.DOCUMENT.equals(structureCurrentNode.getParent().get(PdfName.S))) {
+			PdfDictionary attributes = structureCurrentNode.getAsDict(PdfName.A);
 			if (attributes == null) {
 				attributes = new PdfDictionary();
-				structureCurrentLeaf.put(PdfName.A, attributes);
+				structureCurrentNode.put(PdfName.A, attributes);
 			}
 			attributes.put(PdfNames.PLACEMENT, PdfNames.BLOCK);
 			attributes.put(PdfName.O, PdfNames.LAYOUT);
@@ -1598,13 +1611,13 @@ public class PDFPageDevice implements IPageDevice {
 			// do nothing
 		} else {
 			if (PdfTag.TABLE.equals(tagType)) {
-				PdfName currentTag = structureCurrentLeaf.getAsName(PdfName.S);
+				PdfName currentTag = structureCurrentNode.getAsName(PdfName.S);
 				if (!currentTag.equals(PdfNames.TR)) {
 					// Close the THead/TBody/TFoot tag also
-					structureCurrentLeaf = (PdfStructureElement) structureCurrentLeaf.getParent();
+					structureCurrentNode = (PdfStructureElement) structureCurrentNode.getParent();
 				}
 			}
-			structureCurrentLeaf = (PdfStructureElement) structureCurrentLeaf.getParent();
+			structureCurrentNode = (PdfStructureElement) structureCurrentNode.getParent();
 		}
 	}
 

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPageDevice.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPageDevice.java
@@ -38,8 +38,10 @@ import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.api.ITOCTree;
 import org.eclipse.birt.report.engine.api.TOCNode;
 import org.eclipse.birt.report.engine.api.script.IReportContext;
+import org.eclipse.birt.report.engine.content.IBandContent;
 import org.eclipse.birt.report.engine.content.IReportContent;
 import org.eclipse.birt.report.engine.content.impl.CellContent;
+import org.eclipse.birt.report.engine.content.impl.RowContent;
 import org.eclipse.birt.report.engine.i18n.EngineResourceHandle;
 import org.eclipse.birt.report.engine.i18n.MessageConstants;
 import org.eclipse.birt.report.engine.internal.util.BundleVersionUtil;
@@ -48,6 +50,7 @@ import org.eclipse.birt.report.engine.layout.emitter.IPage;
 import org.eclipse.birt.report.engine.layout.emitter.IPageDevice;
 import org.eclipse.birt.report.engine.nLayout.area.IArea;
 import org.eclipse.birt.report.engine.nLayout.area.impl.CellArea;
+import org.eclipse.birt.report.engine.nLayout.area.impl.ContainerArea;
 
 import com.ibm.icu.util.ULocale;
 import com.lowagie.text.Document;
@@ -76,6 +79,7 @@ import com.lowagie.text.xml.xmp.LangAlt;
 import com.lowagie.text.xml.xmp.PdfA1Schema;
 import com.lowagie.text.xml.xmp.PdfSchema;
 import com.lowagie.text.xml.xmp.XmpBasicSchema;
+import com.lowagie.text.xml.xmp.XmpSchema;
 import com.lowagie.text.xml.xmp.XmpWriter;
 
 /**
@@ -97,19 +101,36 @@ public class PDFPageDevice implements IPageDevice {
 	private static final String PDF_VERSION_1_6 = "1.6";
 	/** PDF version 1.7 */
 	private static final String PDF_VERSION_1_7 = "1.7";
+	/** PDF version 2.0 */
+	private static final String PDF_VERSION_2_0 = "2.0";
 
 	/** PDFX/PDFA conformance */
 	/** PDF conformance PDF Standard */
 	private static final String PDF_CONFORMANCE_STANDARD = "PDF.Standard";
-	/** PDF conformance PDF X-3:2002 */
+	/** PDF conformance PDF/X-3:2002 */
 	private static final String PDF_CONFORMANCE_X32002 = "PDF.X32002";
-	/** PDF conformance PDF A1A */
+	/** PDF conformance PDF/A-1a */
 	private static final String PDF_CONFORMANCE_A1A = "PDF.A1A";
-	/** PDF conformance PDF A1B */
+	/** PDF conformance PDFA-1b */
 	private static final String PDF_CONFORMANCE_A1B = "PDF.A1B";
+	/** PDF conformance PDF/A-2a */
+	private static final String PDF_CONFORMANCE_A2A = "PDF.A2A";
+	/** PDF conformance PDFA-2b */
+	private static final String PDF_CONFORMANCE_A2B = "PDF.A2B";
+	/** PDF conformance PDF/A-3a */
+	private static final String PDF_CONFORMANCE_A3A = "PDF.A3A";
+	/** PDF conformance PDFA-3b */
+	private static final String PDF_CONFORMANCE_A3B = "PDF.A3B";
+	/** PDF conformance PDF/A-3u */
+	private static final String PDF_CONFORMANCE_A3U = "PDF.A3U";
+	/** PDF conformance PDF/A-4f */
+	private static final String PDF_CONFORMANCE_A4F = "PDF.A4F";
+
 	/** PDF conformance PDF X-1a:2001, unsupported (TODO: CMYK of PDF.X1A2001 */
 
 	private static final String PDF_UA_CONFORMANCE_1 = "PDF.UA-1";
+	private static final String PDF_UA_CONFORMANCE_2 = "PDF.UA-2";
+	private static final String PDF_UA_CONFORMANCE_NONE = "none";
 
 	/** PDF ICC color profile */
 	/** PDF ICC default color profile RGB */
@@ -280,7 +301,8 @@ public class PDFPageDevice implements IPageDevice {
 					throw new BirtException("The report needs a locale property for PDF/UA!");
 				}
 				Locale locale = new Locale(localeString);
-				String language = locale.toLanguageTag();
+				String language = locale.toString();
+				language = language.replace('_', '-'); // 'de_de' is invalid, it should be 'de-DE'.
 				doc.setDocumentLanguage(language);
 				// In order to declare the main language of the document,
 				// we need to use the extraCatalog. That way we don't need to
@@ -324,7 +346,7 @@ public class PDFPageDevice implements IPageDevice {
 							// iterate over the list, and create a file inputstream for each file location.
 							for (String s : list.split(",")) {
 								// If there is an exception creating the input stream, don't stop execution.
-								// Just graceffully let the user know that there was an error with the variable.
+								// Just gracefully let the user know that there was an error with the variable.
 								try {
 									String fileName = s.trim().replace("\\", "\\\\");
 									File f = new File(fileName);
@@ -346,15 +368,13 @@ public class PDFPageDevice implements IPageDevice {
 				}
 
 				// The other is a "Named Expression", which is basically a user property that is
-				// the result
-				// of an expression instead of a string literal. This should be set as an
-				// arraylist through
-				// BIRT script
+				// the result of an expression instead of a string literal. This should be set
+				// as an arraylist through BIRT script
 				if (result instanceof ArrayList) {
 					ArrayList<String> pdfList = (ArrayList<String>) result;
-						for (String fileName : pdfList) {
+					for (String fileName : pdfList) {
 						// If there is an exception creating the input stream, don't stop execution.
-						// Just graceffully let the user know that there was an error with the variable.
+						// Just gracefully let the user know that there was an error with the variable.
 						fileName = fileName.replace("\\", "\\\\");
 						try {
 							File f = new File(fileName);
@@ -389,6 +409,9 @@ public class PDFPageDevice implements IPageDevice {
 		}
 	}
 
+	/**
+	 * Initialize the attributes for the PDF tag tree structure.
+	 */
 	public void initStructure() {
 
 		structureRoot = writer.getStructureTreeRoot();
@@ -500,22 +523,21 @@ public class PDFPageDevice implements IPageDevice {
 						// iterate over the list, and create a fileinputstream for each file location.
 						for (String s : list.split(",")) {
 							// If there is an exception creating the input stream, don't stop execution.
-							// Just graceffully let the user know that there was an error with the variable.
+							// Just gracefully let the user know that there was an error with the variable.
 							try {
 								String fileName = s.trim().replace("\\", "\\\\");
-								;
-									File f = new File(fileName);
-									if (f.exists()) {
-										FileInputStream fis = new FileInputStream(f);
-										pdfs.add(fis);
-									} else {
-										// get the file using context.getResource() for relative or universal paths
-										URL url = context.getResource(fileName);
-										InputStream is = new BufferedInputStream(url.openStream());
-										pdfs.add(is);
+								File f = new File(fileName);
+								if (f.exists()) {
+									FileInputStream fis = new FileInputStream(f);
+									pdfs.add(fis);
+								} else {
+									// get the file using context.getResource() for relative or universal paths
+									URL url = context.getResource(fileName);
+									InputStream is = new BufferedInputStream(url.openStream());
+									pdfs.add(is);
 								}
-								} catch (Exception e) {
-									logger.log(Level.WARNING, e.getMessage(), e);
+							} catch (Exception e) {
+								logger.log(Level.WARNING, e.getMessage(), e);
 							}
 						}
 					}
@@ -524,14 +546,13 @@ public class PDFPageDevice implements IPageDevice {
 
 			// option 2: "Named Expression", which is basically a user property that is the
 			// result of an expression instead of a string literal. This should be set as an
-			// arraylist through
-			// BIRT script
+			// arraylist through BIRT script
 			if (result instanceof ArrayList) {
 				ArrayList<String> pdfList = (ArrayList<String>) result;
 
 				for (String fileName : pdfList) {
 					// If there is an exception creating the input stream, don't stop execution.
-					// Just graceffully let the user know that there was an error with the variable.
+					// Just gracefully let the user know that there was an error with the variable.
 					fileName = fileName.replace("\\", "\\\\");
 					try {
 						File f = new File(fileName);
@@ -555,7 +576,7 @@ public class PDFPageDevice implements IPageDevice {
 			}
 		}
 
-		if (this.isPdfAFormat) {
+		if (this.isPdfAFormat || this.isPdfUAFormat) {
 			// PDF/A: set color profile and metadata
 			this.setPdfIccXmp();
 		}
@@ -702,8 +723,10 @@ public class PDFPageDevice implements IPageDevice {
 
 	/**
 	 * Set the PDF version based on the user property
+	 *
+	 * @throws BirtException
 	 */
-	private void setPdfVersion() {
+	private void setPdfVersion() throws BirtException {
 		String userPdfVersion;
 		// PDF version based on user property
 		if (this.userProperties != null && this.userProperties.containsKey(PDFPageDevice.PDF_VERSION)) {
@@ -718,8 +741,9 @@ public class PDFPageDevice implements IPageDevice {
 	 * Set the PDF version
 	 *
 	 * @param version key to set the PDF version (e.g. 1.7)
+	 * @throws BirtException
 	 */
-	public void setPdfVersion(String version) {
+	public void setPdfVersion(String version) throws BirtException {
 		switch (version) {
 		case PDFPageDevice.PDF_VERSION_1_3:
 			this.pdfVersion = PdfWriter.VERSION_1_3;
@@ -736,6 +760,10 @@ public class PDFPageDevice implements IPageDevice {
 		case PDFPageDevice.PDF_VERSION_1_7:
 			this.pdfVersion = PdfWriter.VERSION_1_7;
 			break;
+		case PDFPageDevice.PDF_VERSION_2_0:
+			// this.pdfVersion = PdfWriter.VERSION_2_0;
+			// OpenPDF does not yet support creation of PDF 2.0
+			throw new BirtException("OpenPDF does not yet support creation of PDF 2.0");
 		}
 		// version only set if the PDF version exists
 		if (this.pdfVersion != '0') {
@@ -760,12 +788,17 @@ public class PDFPageDevice implements IPageDevice {
 	/**
 	 * Set the PDF version
 	 *
-	 * @param conformance key to set the PDF version (e.g. 1.7)
+	 * @param conformance key to set the PDF/UA version (e.g. PDF/UA-1)
 	 */
 	public void setPdfUAConformance(String conformance) {
 		switch (conformance) {
 		case PDFPageDevice.PDF_UA_CONFORMANCE_1:
 			this.pdfUAConformance = 1;
+			this.isPdfUAFormat = true;
+			writer.setTagged();
+			break;
+		case PDFPageDevice.PDF_UA_CONFORMANCE_2:
+			this.pdfUAConformance = 2;
 			this.isPdfUAFormat = true;
 			writer.setTagged();
 			break;
@@ -781,8 +814,10 @@ public class PDFPageDevice implements IPageDevice {
 		switch (this.pdfUAConformance) {
 		case 1:
 			return PDFPageDevice.PDF_UA_CONFORMANCE_1;
+		case 2:
+			return PDFPageDevice.PDF_UA_CONFORMANCE_2;
 		default:
-			return PDFPageDevice.PDF_CONFORMANCE_STANDARD;
+			return PDFPageDevice.PDF_UA_CONFORMANCE_NONE;
 		}
 	}
 
@@ -833,6 +868,30 @@ public class PDFPageDevice implements IPageDevice {
 			this.pdfConformance = PdfWriter.PDFA1B;
 			this.isPdfAFormat = true;
 			break;
+		case PDFPageDevice.PDF_CONFORMANCE_A2A:
+			this.pdfConformance = PDFA2A;
+			this.isPdfAFormat = true;
+			break;
+		case PDFPageDevice.PDF_CONFORMANCE_A2B:
+			this.pdfConformance = PDFA2B;
+			this.isPdfAFormat = true;
+			break;
+		case PDFPageDevice.PDF_CONFORMANCE_A3A:
+			this.pdfConformance = PDFA3A;
+			this.isPdfAFormat = true;
+			break;
+		case PDFPageDevice.PDF_CONFORMANCE_A3B:
+			this.pdfConformance = PDFA3B;
+			this.isPdfAFormat = true;
+			break;
+		case PDFPageDevice.PDF_CONFORMANCE_A3U:
+			this.pdfConformance = PDFA3U;
+			this.isPdfAFormat = true;
+			break;
+		case PDFPageDevice.PDF_CONFORMANCE_A4F:
+			this.pdfConformance = PDFA4F;
+			this.isPdfAFormat = true;
+			break;
 		default:
 			this.pdfConformance = PdfWriter.PDFXNONE;
 			this.isPdfAFormat = false;
@@ -843,11 +902,11 @@ public class PDFPageDevice implements IPageDevice {
 		// PDFA: overwrite to get the document title independent of the openPDF
 		// issue of PDF/A-conformance
 		if (this.userProperties != null && this.userProperties.containsKey(PDFPageDevice.PDFA_ADD_DOCUMENT_TITLE)) {
-			this.addPdfADocumentTitle = Boolean.parseBoolean(this.userProperties.get(PDFPageDevice.PDFA_ADD_DOCUMENT_TITLE).toString());
-		} else {
 			this.addPdfADocumentTitle = Boolean
-					.parseBoolean(
-							(String) getReportDesignConfiguration(this.report, PDFPageDevice.PDFA_ADD_DOCUMENT_TITLE));
+					.parseBoolean(this.userProperties.get(PDFPageDevice.PDFA_ADD_DOCUMENT_TITLE).toString());
+		} else {
+			this.addPdfADocumentTitle = Boolean.parseBoolean(
+					(String) getReportDesignConfiguration(this.report, PDFPageDevice.PDFA_ADD_DOCUMENT_TITLE));
 		}
 	}
 
@@ -858,10 +917,25 @@ public class PDFPageDevice implements IPageDevice {
 	 */
 	public void setPdfConformance(int pdfConformance) {
 		writer.setPDFXConformance(pdfConformance);
-		if (pdfConformance == PdfWriter.PDFA1A) {
+		switch (pdfConformance) {
+		case PdfWriter.PDFA1A:
+		case PDFA2A:
+		case PDFA3A:
 			writer.setTagged();
+			break;
+		default:
+			// do nothing
 		}
 	}
+
+	// FIXME THis is a workaround for the fact that OpenPDF does not support PDF/A-2
+	// or newer
+	private static final int PDFA2A = 5;
+	private static final int PDFA2B = 6;
+	private static final int PDFA3A = 7;
+	private static final int PDFA3B = 8;
+	private static final int PDFA3U = 9;
+	private static final int PDFA4F = 10;
 
 	/**
 	 * Get the PDF conformance
@@ -876,6 +950,18 @@ public class PDFPageDevice implements IPageDevice {
 			return PDFPageDevice.PDF_CONFORMANCE_A1A;
 		case PdfWriter.PDFA1B:
 			return PDFPageDevice.PDF_CONFORMANCE_A1B;
+		case PDFA2A:
+			return PDFPageDevice.PDF_CONFORMANCE_A2A;
+		case PDFA2B:
+			return PDFPageDevice.PDF_CONFORMANCE_A2B;
+		case PDFA3A:
+			return PDFPageDevice.PDF_CONFORMANCE_A3A;
+		case PDFA3B:
+			return PDFPageDevice.PDF_CONFORMANCE_A3B;
+		case PDFA3U:
+			return PDFPageDevice.PDF_CONFORMANCE_A3U;
+		case PDFA4F:
+			return PDFPageDevice.PDF_CONFORMANCE_A4F;
 		default:
 			return PDFPageDevice.PDF_CONFORMANCE_STANDARD;
 		}
@@ -899,27 +985,67 @@ public class PDFPageDevice implements IPageDevice {
 		return this.isPdfUAFormat;
 	}
 
-	/**
-	 * We need to override getXmlns because we have to define the pdfuaid namespace.
-	 */
-	private static class DublinCoreAccessibleSchema extends DublinCoreSchema {
+	private static class PDFUASchema extends XmpSchema {
 
-		public DublinCoreAccessibleSchema() {
-			super();
-		}
+		/**
+		 *
+		 */
+		private static final long serialVersionUID = -6990512370284803429L;
 
-		@Override
-		public String getXmlns() {
-			return super.getXmlns() + " xmlns:pdfuaid=\"http://www.aiim.org/pdfua/ns/id/\"";
+		public PDFUASchema() {
+			super("xmlns:pdfuaid=\"http://www.aiim.org/pdfua/ns/id/\"");
 		}
 
 		/**
 		 * This is what declares the document to be PDF/UA-1, so it must be called.
+		 *
+		 * @param version the PDF/UA version. Valid values are 1 or 2.
 		 */
 		public void addPdfUAId(int version) {
 			setProperty("pdfuaid:part", String.valueOf(version));
 		}
 
+	}
+
+	private static class PDFAExtensionSchema extends XmpSchema {
+
+		/**
+		 *
+		 */
+		private static final long serialVersionUID = 6654512771721220538L;
+
+		public PDFAExtensionSchema() {
+			super("xmlns:pdfaExtension=\"http://www.aiim.org/pdfa/ns/extension/\" xmlns:pdfaProperty=\"http://www.aiim.org/pdfa/ns/property#\" xmlns:pdfaSchema=\"http://www.aiim.org/pdfa/ns/schema#\"");
+		}
+
+		public String toString() {
+			return "            <pdfaExtension:schemas>\r\n" + "                <rdf:Bag>\r\n"
+					+ "                    <rdf:li rdf:parseType=\"Resource\">\r\n"
+					+ "                        <pdfaSchema:namespaceURI>http://www.aiim.org/pdfua/ns/id/</pdfaSchema:namespaceURI>\r\n"
+					+ "                        <pdfaSchema:prefix>pdfuaid</pdfaSchema:prefix>\r\n"
+					+ "                        <pdfaSchema:schema>PDF/UA identification schema</pdfaSchema:schema>\r\n"
+					+ "                        <pdfaSchema:property>\r\n" + "                            <rdf:Seq>\r\n"
+					+ "                                <rdf:li rdf:parseType=\"Resource\">\r\n"
+					+ "                                    <pdfaProperty:category>internal</pdfaProperty:category>\r\n"
+					+ "                                    <pdfaProperty:description>PDF/UA version identifier</pdfaProperty:description>\r\n"
+					+ "                                    <pdfaProperty:name>part</pdfaProperty:name>\r\n"
+					+ "                                    <pdfaProperty:valueType>Integer</pdfaProperty:valueType>\r\n"
+					+ "                                </rdf:li>\r\n"
+					+ "                                <rdf:li rdf:parseType=\"Resource\">\r\n"
+					+ "                                    <pdfaProperty:category>internal</pdfaProperty:category>\r\n"
+					+ "                                    <pdfaProperty:description>PDF/UA amendment identifier</pdfaProperty:description>\r\n"
+					+ "                                    <pdfaProperty:name>amd</pdfaProperty:name>\r\n"
+					+ "                                    <pdfaProperty:valueType>Text</pdfaProperty:valueType>\r\n"
+					+ "\r\n" + "                                </rdf:li>\r\n"
+					+ "                                <rdf:li rdf:parseType=\"Resource\">\r\n"
+					+ "                                    <pdfaProperty:category>internal</pdfaProperty:category>\r\n"
+					+ "                                    <pdfaProperty:description>PDF/UA corrigenda identifier</pdfaProperty:description>\r\n"
+					+ "                                    <pdfaProperty:name>corr</pdfaProperty:name>\r\n"
+					+ "                                    <pdfaProperty:valueType>Text</pdfaProperty:valueType>\r\n"
+					+ "                                </rdf:li>\r\n" + "                            </rdf:Seq>\r\n"
+					+ "                        </pdfaSchema:property>\r\n" + "                    </rdf:li>\r\n"
+					+ "                </rdf:Bag>\r\n" + "            </pdfaExtension:schemas>\r\n" + "";
+		}
 	}
 
 	/**
@@ -939,7 +1065,7 @@ public class PDFPageDevice implements IPageDevice {
 			// Not tested.
 			int PdfXConformance = writer.getPDFXConformance();
 			XmpWriter xmp = new XmpWriter(baos, "UTF-8", 4);
-			DublinCoreAccessibleSchema dc = new DublinCoreAccessibleSchema();
+			DublinCoreSchema dc = new DublinCoreSchema();
 			PdfSchema p = new PdfSchema();
 			XmpBasicSchema basic = new XmpBasicSchema();
 
@@ -982,10 +1108,6 @@ public class PDFPageDevice implements IPageDevice {
 					basic.addModDate(((PdfDate) obj).getW3CDate());
 				}
 			}
-			if (this.isPDFUAFormat()) {
-				// Declare the document to be PDF/UA conformant.
-				dc.addPdfUAId(this.pdfUAConformance);
-			}
 
 			if (dc.size() > 0)
 				xmp.addRdfDescription(dc);
@@ -994,13 +1116,56 @@ public class PDFPageDevice implements IPageDevice {
 			if (basic.size() > 0)
 				xmp.addRdfDescription(basic);
 
-			// Declare the document to be PDF/A conformant, if requested by the developer.
-			if (PdfXConformance == PdfWriter.PDFA1A || PdfXConformance == PdfWriter.PDFA1B) {
+			if (this.isPDFUAFormat()) {
+				// Declare the document to be PDF/UA conforming.
+				PDFUASchema ua = new PDFUASchema();
+				ua.addPdfUAId(this.pdfUAConformance);
+				xmp.addRdfDescription(ua);
+			}
+
+			// Declare the document to be PDF/A conforming, if requested by the developer.
+			if (isPdfAFormat) {
+
+				// If the document is also PDF/UA conforming, we need to add a description of
+				// that schema as an PDF/A extension.
+				if (isPDFUAFormat()) {
+					PDFAExtensionSchema pdfaext = new PDFAExtensionSchema();
+					xmp.addRdfDescription(pdfaext);
+				}
+
 				PdfA1Schema a1 = new PdfA1Schema();
-				if (PdfXConformance == PdfWriter.PDFA1A)
+				switch (PdfXConformance) {
+				case PdfWriter.PDFA1A:
+				case PdfWriter.PDFA1B:
+					a1.addPart("1");
+					break;
+				case PDFA2A:
+				case PDFA2B:
+					a1.addPart("2");
+					break;
+				case PDFA3A:
+				case PDFA3B:
+				case PDFA3U:
+					a1.addPart("3");
+					break;
+				case PDFA4F:
+					a1.addPart("4");
+					break;
+				}
+				switch (PdfXConformance) {
+				case PdfWriter.PDFA1A:
+				case PDFA2A:
+				case PDFA3A:
 					a1.addConformance("A");
-				else
+					break;
+				case PdfWriter.PDFA1B:
+				case PDFA2B:
+				case PDFA3B:
 					a1.addConformance("B");
+					break;
+				case PDFA4F:
+					a1.addConformance("F");
+				}
 				xmp.addRdfDescription(a1);
 			}
 
@@ -1031,10 +1196,13 @@ public class PDFPageDevice implements IPageDevice {
 			String fullFileNameIcc = "";
 			if (this.userProperties != null
 					&& userProperties.containsKey(PDFPageDevice.PDF_ICC_PROFILE_EXTERNAL_FILE)) {
-				fullFileNameIcc = userProperties.get(PDFPageDevice.PDF_ICC_PROFILE_EXTERNAL_FILE).toString().trim();
+				fullFileNameIcc = userProperties.get(PDFPageDevice.PDF_ICC_PROFILE_EXTERNAL_FILE).toString();
 			} else {
 				fullFileNameIcc = ((String) getReportDesignConfiguration(this.report,
-						PDFPageDevice.PDF_ICC_PROFILE_EXTERNAL_FILE)).trim();
+						PDFPageDevice.PDF_ICC_PROFILE_EXTERNAL_FILE));
+			}
+			if (fullFileNameIcc != null) {
+				fullFileNameIcc = fullFileNameIcc.trim();
 			}
 			if (fullFileNameIcc != null && fullFileNameIcc.length() > 0) {
 				try {
@@ -1186,67 +1354,188 @@ public class PDFPageDevice implements IPageDevice {
 	}
 
 	/**
-	 * @param tagType
+	 * Open a tag in the tag tree structure.
+	 *
+	 * Basically this means: Create a new child node for structureCurrentLeaf and
+	 * let structureCurrentLeaf point to this child node. But several edge cases
+	 * need special handling. For example, when we are in an artifact, we don't want
+	 * to open a new tag. And containers need special handling for page-breaking to
+	 * avoid the creation of unnecessary tags, e.g. a table that spans two pages
+	 * must still a single table in the tag tree.
+	 *
+	 * If the PDF emitter is not configured to create tagged PDF, then this method
+	 * is a no-op.
+	 *
+	 * @param tagType the tag type. Note that we use some special tag types AUTO,
+	 *                PAGE_HEADER and PAGE_FOOTER which are not actually PDF tags,
+	 *                but plcaeholders which trigger special handling here.
+	 * @param area    the area for which we create a tag.
 	 */
-	public void pushTag(String tagType, IArea area) {
-		if (!writer.isTagged()) {
+	public void openTag(String tagType, IArea area) {
+		if (!writer.isTagged() || tagType == null) {
 			return;
 		}
-		if ("pageHeader".equals(tagType)) {
-			currentPage.beginArtifact();
-		} else if ("pageFooter".equals(tagType)) {
-			currentPage.beginArtifact();
-		} else if (currentPage.isInArtifact()) {
-			;
-		} else {
-			structureCurrentLeaf = new PdfStructureElement(structureCurrentLeaf, new PdfName(tagType));
-			// FIXME Adding attributes should be made a method of the IArea classes.
-			if ("Figure".equals(tagType)) {
-				// Top-Level figure elements must have a placement attribute.
-				if (PdfName.DOCUMENT.equals(structureCurrentLeaf.getParent().get(PdfName.S))) {
-					PdfDictionary attributes = structureCurrentLeaf.getAsDict(PdfName.A);
-					if (attributes == null) {
-						attributes = new PdfDictionary();
-						structureCurrentLeaf.put(PdfName.A, attributes);
+		PdfDictionary properties = null;
+		switch (tagType) {
+		case PdfTag.AUTO:
+			System.err.println("TODO: auto TagType found for area: " + area);
+			break;
+		case PdfTag.PAGE_HEADER:
+			properties = new PdfDictionary();
+			properties.put(PdfNames.TYPE, PdfNames.PAGINATION);
+			properties.put(PdfNames.SUBTYPE, PdfNames.HEADER);
+			currentPage.beginArtifact(properties);
+			break;
+		case PdfTag.PAGE_FOOTER:
+			properties = new PdfDictionary();
+			properties.put(PdfNames.TYPE, PdfNames.PAGINATION);
+			properties.put(PdfNames.SUBTYPE, PdfNames.FOOTER);
+			currentPage.beginArtifact(properties);
+			break;
+		default:
+			if (area instanceof ContainerArea && ((ContainerArea) area).isArtifact()) {
+				properties = new PdfDictionary();
+				// FIXME: It is not clear if Pagination or Page is the appropriate type for
+				// repeated header rows.
+				properties.put(PdfNames.TYPE, PdfNames.PAGINATION);
+				currentPage.beginArtifact(properties);
+			} else if (currentPage.isInArtifact()) {
+				// Do not open a tag inside artifacts.
+			} else {
+				if (area instanceof ContainerArea) {
+					final ContainerArea container = (ContainerArea) area;
+					if (container.isFirstPart()) {
+						if (PdfTag.TR.equals(tagType)) {
+							beforeOpenTableSectionTag(container);
+						}
+						structureCurrentLeaf = new PdfStructureElement(structureCurrentLeaf, new PdfName(tagType));
+						try {
+							container.setStructureElement(structureCurrentLeaf);
+						} catch (BirtException be) {
+							be.printStackTrace();
+							structureCurrentLeaf = new PdfStructureElement(structureCurrentLeaf, new PdfName(tagType));
+						}
+					} else {
+						structureCurrentLeaf = container.getFirstPart().getStructureElement();
+						PdfName restored = structureCurrentLeaf.getAsName(PdfName.S);
+						if (PdfName.TABLE.equals(restored)) {
+							// Also restore the table section, e.g. TBody.
+							PdfArray kids = structureCurrentLeaf.getAsArray(PdfName.K);
+							if (kids != null && kids.size() > 0) {
+								structureCurrentLeaf = (PdfStructureElement) kids.getAsDict(kids.size() - 1);
+							}
+						}
 					}
-					attributes.put(new PdfName("Placement"), new PdfName("Block"));
-					attributes.put(PdfName.O, new PdfName("Layout"));
+				} else {
+					structureCurrentLeaf = new PdfStructureElement(structureCurrentLeaf, new PdfName(tagType));
+				}
+				if (PdfTag.FIGURE.equals(tagType)) {
+					addFigureAttributes();
+				}
+				if (PdfTag.TD.equals(tagType) || PdfTag.TH.equals(tagType)) {
+					addTableCellAttributes(tagType, area);
 				}
 			}
-			if ("TD".equals(tagType) || "TH".equals(tagType)) {
-				if (area instanceof CellArea) {
-					CellArea cellArea = (CellArea) area;
-					int rowspan = cellArea.getRowSpan();
-					int colspan = cellArea.getColSpan();
-					String scope = ((CellContent) (cellArea.getContent())).getScope();
-					String bookmark = cellArea.getBookmark();
-					if (bookmark != null) {
-						structureCurrentLeaf.put(PdfName.ID, new PdfString(bookmark));
-					}
+		}
+	}
 
-					String headers = ((CellContent) (cellArea.getContent())).getHeaders();
-					if (rowspan != 1 || colspan != 1 || scope != null || headers != null) {
-						PdfDictionary attributes = structureCurrentLeaf.getAsDict(PdfName.A);
-						if (attributes == null) {
-							attributes = new PdfDictionary();
-							attributes.put(PdfName.O, PdfName.TABLE);
-							structureCurrentLeaf.put(PdfName.A, attributes);
-						}
-						if (rowspan != 1) {
-							attributes.put(new PdfName("RowSpan"), new PdfNumber(rowspan));
-						}
-						if (colspan != 1) {
-							attributes.put(new PdfName("ColSpan"), new PdfNumber(colspan));
-						}
-						if (scope != null && "TH".equals(tagType)) {
-							attributes.put(new PdfName("Scope"), pdfScope((scope)));
-						}
-						if (headers != null) {
-							attributes.put(new PdfName("Headers"), commaSeparatedToPdfByteStringArray((headers)));
-						}
-					}
+	/**
+	 * Open a tag for the table section THead, TBody, TFoot when necessary.
+	 *
+	 * When opening a row, we want to open e.g. a TBody tag if it is the first row
+	 * of the table body. If we are still in the wrong section, we have to close
+	 * that section tag first before opening the new section tag.
+	 *
+	 * @param row the RowArea.
+	 */
+	private void beforeOpenTableSectionTag(final ContainerArea row) {
+		PdfName currentTag = structureCurrentLeaf.getAsName(PdfName.S);
+		RowContent rowContent = (RowContent) row.getContent();
+		PdfName inject = null;
+		boolean closeSection = false;
+		switch (rowContent.getBand().getBandType()) {
+		case IBandContent.BAND_HEADER:
+			// THead
+			if (!currentTag.equals(PdfName.THEAD)) {
+				inject = PdfName.THEAD;
+			}
+			break;
+		case IBandContent.BAND_FOOTER:
+			// TFoot
+			if (!currentTag.equals(PdfName.TFOOT)) {
+				inject = PdfName.TFOOT;
+				closeSection = !currentTag.equals(PdfName.TABLE);
+			}
+			break;
+		default:
+			// TBody
+			if (!currentTag.equals(PdfName.TBODY)) {
+				inject = PdfName.TBODY;
+				closeSection = !currentTag.equals(PdfName.TABLE);
+			}
+		}
+		if (closeSection) {
+			structureCurrentLeaf = (PdfStructureElement) structureCurrentLeaf.getParent();
+		}
+		if (inject != null) {
+			structureCurrentLeaf = new PdfStructureElement(structureCurrentLeaf, inject);
+		}
+	}
+
+	/**
+	 * Add attributes for a table cell.
+	 *
+	 * They are necessary to connect TD cells with their corresponding TH cells.
+	 */
+	private void addTableCellAttributes(String tagType, IArea area) {
+		if (area instanceof CellArea) {
+			CellArea cellArea = (CellArea) area;
+			int rowspan = cellArea.getRowSpan();
+			int colspan = cellArea.getColSpan();
+			String scope = ((CellContent) (cellArea.getContent())).getScope();
+			String bookmark = cellArea.getBookmark();
+			if (bookmark != null) {
+				structureCurrentLeaf.put(PdfName.ID, new PdfString(bookmark));
+			}
+
+			String headers = ((CellContent) (cellArea.getContent())).getHeaders();
+			if (rowspan != 1 || colspan != 1 || scope != null || headers != null) {
+				PdfDictionary attributes = structureCurrentLeaf.getAsDict(PdfName.A);
+				if (attributes == null) {
+					attributes = new PdfDictionary();
+					attributes.put(PdfName.O, PdfName.TABLE);
+					structureCurrentLeaf.put(PdfName.A, attributes);
+				}
+				if (rowspan != 1) {
+					attributes.put(PdfNames.ROWSPAN, new PdfNumber(rowspan));
+				}
+				if (colspan != 1) {
+					attributes.put(PdfNames.COLSPAN, new PdfNumber(colspan));
+				}
+				if (scope != null && PdfTag.TH.equals(tagType)) {
+					attributes.put(PdfNames.SCOPE, pdfScope((scope)));
+				}
+				if (headers != null) {
+					attributes.put(PdfNames.HEADERS, commaSeparatedToPdfByteStringArray((headers)));
 				}
 			}
+		}
+	}
+
+	/**
+	 * Add necessary attributes for figure tags.
+	 *
+	 * Top-Level figure elements must have a placement attribute.
+	 */
+	private void addFigureAttributes() {
+		if (PdfName.DOCUMENT.equals(structureCurrentLeaf.getParent().get(PdfName.S))) {
+			PdfDictionary attributes = structureCurrentLeaf.getAsDict(PdfName.A);
+			if (attributes == null) {
+				attributes = new PdfDictionary();
+				structureCurrentLeaf.put(PdfName.A, attributes);
+			}
+			attributes.put(PdfNames.PLACEMENT, PdfNames.BLOCK);
+			attributes.put(PdfName.O, PdfNames.LAYOUT);
 		}
 	}
 
@@ -1274,35 +1563,53 @@ public class PDFPageDevice implements IPageDevice {
 			return null;
 		}
 		if ("col".equals(scope)) {
-			return new PdfName("Column");
+			return PdfNames.COLUMN;
 		}
 		if ("row".equals(scope)) {
-			return new PdfName("Row");
+			return PdfNames.ROW;
 		}
 		logger.warning("Unsupported scope: " + scope);
 		return null;
 	}
 
 	/**
-	 * @param tagType
+	 * This is the opposite of openTag.
+	 *
+	 * Every tag that has been opened must be closed exactly once.
+	 *
+	 *
+	 * If the PDF emitter is not configured to create tagged PDF, then this method
+	 * is a no-op.
+	 *
+	 * @param tagType must be the same as in the call to openTag.
+	 * @param area    must be the same as in the call to openTag.
 	 */
-	public void popTag(String tagType) {
-		if (!writer.isTagged()) {
+	public void closeTag(String tagType, IArea area) {
+		if (!writer.isTagged() || tagType == null) {
 			return;
 		}
 		if ("pageHeader".equals(tagType)) {
 			currentPage.endArtifact();
 		} else if ("pageFooter".equals(tagType)) {
 			currentPage.endArtifact();
+		} else if (area instanceof ContainerArea && ((ContainerArea) area).isArtifact()) {
+			currentPage.endArtifact();
 		} else if (currentPage.isInArtifact()) {
-			;
+			// do nothing
 		} else {
+			if (PdfTag.TABLE.equals(tagType)) {
+				PdfName currentTag = structureCurrentLeaf.getAsName(PdfName.S);
+				if (!currentTag.equals(PdfNames.TR)) {
+					// Close the THead/TBody/TFoot tag also
+					structureCurrentLeaf = (PdfStructureElement) structureCurrentLeaf.getParent();
+				}
+			}
 			structureCurrentLeaf = (PdfStructureElement) structureCurrentLeaf.getParent();
 		}
 	}
 
 	/**
-	 * Is the writer is expected to create tagged PDF or not?
+	 * @return Is the writer is expected to create tagged PDF or not?
 	 */
 	public boolean isTagged() {
 		return writer.isTagged();

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PdfNames.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PdfNames.java
@@ -3,6 +3,32 @@ package org.eclipse.birt.report.engine.emitter.pdf;
 import com.lowagie.text.pdf.PdfName;
 
 /**
+ * Some standard PdfName constants which are used inside BIRT code, but are
+ * missing in OpenPDF's PdfName class.
+ *
+ * As soon as OpenPDF also defines theses name constants, the corresponding
+ * names should be removed here and references to them should be replace with
+ * references to the OpenPDF's PdfName.
+ *
+ * A long term goal is to get rid of this class in BIRT once all names are
+ * defined in OpenPDF.
+ *
+ * Some of these names are PDF tag names, some are names of attributes, some are
+ * used for values of attributes.
+ *
+ * If you wonder, why we only have some constants here and create other PdfName
+ * objects from strings on the fly: It's because we hope to get the best
+ * performance this way. This class is related to class {@link PdfTag}. Creating
+ * a {@link com.lowagie.text.pdf.PdfName} involves a little overhead, and
+ * comparing it to another instance is a bit more complex than comparing two
+ * strings. We create these constant values here a priori when we need the name
+ * in source code, whereas we create the PdfName objects on the fly when the
+ * name is read from a design file.
+ *
+ * For a description of the usage of the names, please refer to the PDF
+ * specification EN/ISO 32000, in particular the sections about tagged PDF and
+ * accessibility.
+ *
  * @since 4.19
  *
  */

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PdfNames.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PdfNames.java
@@ -1,0 +1,30 @@
+package org.eclipse.birt.report.engine.emitter.pdf;
+
+import com.lowagie.text.pdf.PdfName;
+
+/**
+ * @since 4.19
+ *
+ */
+@SuppressWarnings("javadoc")
+public final class PdfNames {
+
+	public static final PdfName ALT = new PdfName("Alt");
+	public static final PdfName ARTIFACT = new PdfName("Artifact");
+	public static final PdfName BACKGROUND = PdfName.BACKGROUND;
+	public static final PdfName BLOCK = new PdfName("Block");
+	public static final PdfName COLSPAN = new PdfName("ColSpan");
+	public static final PdfName COLUMN = new PdfName("Column");
+	public static final PdfName FOOTER = new PdfName("Footer");
+	public static final PdfName HEADER = new PdfName("Header");
+	public static final PdfName HEADERS = new PdfName("Headers");
+	public static final PdfName LAYOUT = new PdfName("Layout");
+	public static final PdfName PAGINATION = new PdfName("Pagination");
+	public static final PdfName PLACEMENT = new PdfName("Placement");
+	public static final PdfName ROW = new PdfName("Row");
+	public static final PdfName ROWSPAN = new PdfName("RowSpan");
+	public static final PdfName SCOPE = new PdfName("Scope");
+	public static final PdfName SUBTYPE = PdfName.SUBTYPE;
+	public static final PdfName TYPE = PdfName.TYPE;
+	public static final PdfName TR = new PdfName(PdfTag.TR);
+}

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PdfTag.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PdfTag.java
@@ -1,17 +1,42 @@
 package org.eclipse.birt.report.engine.emitter.pdf;
 
 /**
+ * String constants for PDF tag names which are used by BIRT. These are tag
+ * names used for tagged PDF and PDF/UA, with a few exceptions which are
+ * meaningful only inside BIRT.
+ *
  * @since 4.19
  */
-@SuppressWarnings("javadoc")
 public final class PdfTag {
+
+	/**
+	 * This is not a PDF tag name, but used as a place-holder.
+	 *
+	 * The actual PDF tag name will be set depending on the context.
+	 */
 	public static final String AUTO = "auto";
+
+	/** PDF tag used for the page header. */
 	public static final String PAGE_HEADER = "pageHeader";
+
+	/** PDF tag used for the page footer. */
 	public static final String PAGE_FOOTER = "pageFooter";
+
+	/** PDF tag used for images and charts. */
 	public static final String FIGURE = "Figure";
+
+	/** PDF tag used for hyperlinks. */
 	public static final String LINK = "Link";
+
+	/** PDF tag used for tables (but not for grids!). */
 	public static final String TABLE = "Table";
+
+	/** PDF tag used for table rows. */
 	public static final String TR = "TR";
+
+	/** PDF tag used for table header cells. */
 	public static final String TH = "TH";
+
+	/** PDF tag used for table data cells. */
 	public static final String TD = "TD";
 }

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PdfTag.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PdfTag.java
@@ -1,0 +1,17 @@
+package org.eclipse.birt.report.engine.emitter.pdf;
+
+/**
+ * @since 4.19
+ */
+@SuppressWarnings("javadoc")
+public final class PdfTag {
+	public static final String AUTO = "auto";
+	public static final String PAGE_HEADER = "pageHeader";
+	public static final String PAGE_FOOTER = "pageFooter";
+	public static final String FIGURE = "Figure";
+	public static final String LINK = "Link";
+	public static final String TABLE = "Table";
+	public static final String TR = "TR";
+	public static final String TH = "TH";
+	public static final String TD = "TD";
+}

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/README.md
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/README.md
@@ -27,7 +27,7 @@ The following list get an overview of all supported user properties, the content
 	Content    	define the PDF conformance of the created PDF document, e.g. PDF.A1A
 	Location   	report
 	Data type  	string
-	Values     	PDF.Standard, PDF.X1A2001, PDF.X32002, PDF.A1A, PDF.A1B
+	Values     	PDF.Standard, PDF.X1A2001, PDF.X32002, PDF.A1A, PDF.A1B, PDF.A2A, PDF.A2B, PDF.A3A, PDF.A3B, PDF.A3U, PDF.A4F
 	Default    	PDF.Standard
 	Reference  	see PdfEmitter.IccColorType, PdfEmitter.IccProfileFile, PdfEmitter.PDFA.AddDocumentTitle, PdfEmitter.PDFA.FallbackFont, PdfEmitter.IncludeCidSet
 	Since      	4.16
@@ -39,8 +39,8 @@ The following list get an overview of all supported user properties, the content
 	Content    	define the PDF/UA conformance of the created PDF document, e.g. PDF.UA-1
 	Location   	report
 	Data type  	string
-	Values     	PDF.Standard, PDF.UA-1
-	Default    	PDF.Standard
+	Values     	none, PDF.UA-1, PDF.UA-2
+	Default    	none
 	Since      	4.18
 	Designer  	4.18
 

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/TOCHandler.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/TOCHandler.java
@@ -86,8 +86,8 @@ public class TOCHandler {
 	/**
 	 * create a PDF outline for tocNode, using the pol as the parent PDF outline.
 	 *
-	 * @param tocNode   The tocNode whose kids need to build a PDF outline tree
-	 * @param pol       The parent PDF outline for these kids
+	 * @param tocNode   The tocNode whose children need to build a PDF outline tree
+	 * @param pol       The parent PDF outline for these children
 	 * @param bookmarks All bookMarks created during rendering
 	 */
 	protected void createTOC(TOCNode tocNode, PdfOutline pol, Set<String> bookmarks) {

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/executor/ReportItemExecutor.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/executor/ReportItemExecutor.java
@@ -708,10 +708,11 @@ public abstract class ReportItemExecutor implements IReportItemExecutor {
 	protected void startGroupTOCEntry(IGroupContent group) {
 		TOCBuilder tocBuilder = context.getTOCBuilder();
 		if (tocBuilder != null) {
-			TOCEntry entry = getParentTOCEntry();
+			TOCEntry parentTOCEntry = getParentTOCEntry();
 			String hiddenFormats = group.getStyle().getVisibleFormat();
 			long elementId = getElementId();
-			tocEntry = tocBuilder.startGroupEntry(entry, group.getTOC(), group.getBookmark(), hiddenFormats, elementId);
+			tocEntry = tocBuilder.startGroupEntry(parentTOCEntry, group.getTOC(), group.getBookmark(), hiddenFormats,
+					elementId);
 			String tocId = tocEntry.getNodeId();
 			if (group.getBookmark() == null) {
 				group.setBookmark(tocId);

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/executor/ReportItemExecutor.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/executor/ReportItemExecutor.java
@@ -30,14 +30,11 @@ import org.eclipse.birt.data.engine.api.IQueryDefinition;
 import org.eclipse.birt.report.engine.api.DataID;
 import org.eclipse.birt.report.engine.api.DataSetID;
 import org.eclipse.birt.report.engine.api.InstanceID;
-import org.eclipse.birt.report.engine.content.IBandContent;
 import org.eclipse.birt.report.engine.content.IContent;
 import org.eclipse.birt.report.engine.content.IGroupContent;
 import org.eclipse.birt.report.engine.content.IHyperlinkAction;
 import org.eclipse.birt.report.engine.content.IReportContent;
-import org.eclipse.birt.report.engine.content.impl.CellContent;
 import org.eclipse.birt.report.engine.content.impl.Column;
-import org.eclipse.birt.report.engine.content.impl.RowContent;
 import org.eclipse.birt.report.engine.extension.IBaseResultSet;
 import org.eclipse.birt.report.engine.extension.ICubeResultSet;
 import org.eclipse.birt.report.engine.extension.IExecutorContext;
@@ -619,17 +616,6 @@ public abstract class ReportItemExecutor implements IReportItemExecutor {
 			DesignElementHandle h = ((DesignElementHandle) (rid.getHandle()));
 			if (h != null) {
 				content.setTagType(h.getTagType());
-				if (content instanceof CellContent) {
-					CellContent cell = (CellContent) content;
-					RowContent row = (RowContent)cell.getParent();
-					if (row.getBand() != null) {
-						int bandType = row.getBand().getBandType();
-						// FIXME This prevents that the report designer can override the tag type.
-						if (bandType == IBandContent.BAND_HEADER || bandType == IBandContent.BAND_GROUP_HEADER) {
-							content.setTagType("TH");
-						}
-					}
-				}
 			}
 		}
 	}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/i18n/Messages.properties
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/i18n/Messages.properties
@@ -117,7 +117,7 @@ Error.ResultsetExtractError = Result set not found.
 Error.FailedToInitializeEmitter = Failed to initialize emitter.
 
 ###########################################################
-PDFCreator = BIRT Report Engine {0}.
+PDFCreator = BIRT Report Engine {0}
 
 ###########################################################
 Error.FlashObjectNotSupported = Flash object report items are not supported in this report format.

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/pdf/util/HTML2Content.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/layout/pdf/util/HTML2Content.java
@@ -633,7 +633,7 @@ public class HTML2Content implements HTMLConstants {
 				if ("".equals(text.getText())) // add default list type when tag <ul> attribute is empty.
 				{
 					text.setText("\u2022"); // the disc type
-					text.setTagType("Lbl"); // TODO HVB check if this is correct
+					text.setTagType("Lbl");
 				}
 			}
 
@@ -684,11 +684,40 @@ public class HTML2Content implements HTMLConstants {
 		} else if (htmlBlockDisplay.contains(lTagName) || htmlInlineDisplay.contains(lTagName)) {
 			IContainerContent container = content.getReportContent().createContainerContent();
 			handleStyle(ele, cssStyles, container);
+			mapHtmlTagToPdfTag(container, lTagName);
 			addChild(content, container);
 			// handleStyle(ele, cssStyles, container);
 			processNodes(ele, cssStyles, container, action, nestCount);
 		} else {
 			processNodes(ele, cssStyles, content, action, nestCount);
+		}
+	}
+
+	// FIXME: The mapping should be configurable.
+	// FIXME: In particular, it should be possible to adjust the heading levels,
+	// (i.e to specify a positive or negative offset, such that H1->H2, H2->H3).
+	static final Map<String, String> HTML_TAG_TO_PDF_TAG = Map.of(
+			"DIV", "DIV",
+			"P", "P",
+			"H1", "H1",
+			"H2", "H2",
+			"H3", "H3",
+			"H4", "H4"
+		);
+
+	/**
+	 * This sets the container's tag type corresponding to the HTML tag, if
+	 * possible.
+	 *
+	 * @param container
+	 * @param lTagName
+	 */
+	private static void mapHtmlTagToPdfTag(IContainerContent container, String lTagName) {
+		if (lTagName == null)
+			return;
+		String mapped = HTML_TAG_TO_PDF_TAG.get(lTagName.toUpperCase());
+		if (mapped != null) {
+			container.setTagType(mapped);
 		}
 	}
 

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/PdfTagConstant.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/PdfTagConstant.java
@@ -1,0 +1,19 @@
+package org.eclipse.birt.report.engine.nLayout;
+
+/**
+ * Some constants are duplicated here to avoid dependencies.
+ *
+ * @see org.eclipse.birt.report.engine.emitter.pdf.PdfTag
+ *
+ * @since 4.19
+ *
+ */
+public class PdfTagConstant {
+	public static final String AUTO = "auto";
+	public static final String NONSTRUCT = "NonStruct";
+	public static final String P = "P";
+	public static final String TD = "TD";
+	public static final String TH = "TH";
+	public static final String TR = "TR";
+
+}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/BlockContainerArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/BlockContainerArea.java
@@ -23,9 +23,11 @@ import java.util.ListIterator;
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.content.IContent;
 import org.eclipse.birt.report.engine.content.IStyle;
+import org.eclipse.birt.report.engine.content.impl.ForeignContent;
 import org.eclipse.birt.report.engine.css.engine.StyleConstants;
 import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.eclipse.birt.report.engine.nLayout.LayoutContext;
+import org.eclipse.birt.report.engine.nLayout.PdfTagConstant;
 import org.eclipse.birt.report.engine.nLayout.area.IArea;
 import org.eclipse.birt.report.engine.nLayout.area.IContainerArea;
 import org.eclipse.birt.report.engine.nLayout.area.style.BoxStyle;
@@ -252,16 +254,22 @@ public class BlockContainerArea extends ContainerArea implements IContainerArea 
 
 	@Override
 	public SplitResult split(int height, boolean force) throws BirtException {
+		final SplitResult ret;
 		if (force) {
-			return _split(height, true);
+			ret = _split(height, true);
 		} else if (isPageBreakInsideAvoid()) {
 			if (isPageBreakBeforeAvoid()) {
-				return SplitResult.BEFORE_AVOID_WITH_NULL;
+				ret = SplitResult.BEFORE_AVOID_WITH_NULL;
+			} else {
+				ret = SplitResult.SUCCEED_WITH_NULL;
 			}
-			return SplitResult.SUCCEED_WITH_NULL;
 		} else {
-			return _split(height, false);
+			ret = _split(height, false);
 		}
+		if (ret.getResult() != null) {
+			setPreviousPart(ret.getResult());
+		}
+		return ret;
 	}
 
 	protected SplitResult _split(int height, boolean force) throws BirtException {
@@ -501,6 +509,17 @@ public class BlockContainerArea extends ContainerArea implements IContainerArea 
 		} else {
 			setContentHeight(0);
 		}
+	}
+
+	@Override
+	public String getTagType() {
+		String tagType = super.getTagType();
+		if (PdfTagConstant.AUTO.equals(tagType)) {
+			if (getContent() instanceof ForeignContent) {
+				tagType = PdfTagConstant.NONSTRUCT;
+			}
+		}
+		return tagType;
 	}
 
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/BlockTextArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/BlockTextArea.java
@@ -24,6 +24,7 @@ import org.eclipse.birt.report.engine.content.IStyle;
 import org.eclipse.birt.report.engine.content.ITextContent;
 import org.eclipse.birt.report.engine.layout.pdf.util.PropertyUtil;
 import org.eclipse.birt.report.engine.nLayout.LayoutContext;
+import org.eclipse.birt.report.engine.nLayout.PdfTagConstant;
 import org.eclipse.birt.report.engine.nLayout.area.IArea;
 import org.eclipse.birt.report.engine.nLayout.area.ILayout;
 import org.w3c.dom.css.CSSValue;
@@ -201,6 +202,15 @@ public class BlockTextArea extends BlockContainerArea implements ILayout {
 
 	public void setHelpText(String helpText) {
 		this.helpText = helpText;
+	}
+
+	@Override
+	public String getTagType() {
+		String tagType = super.getTagType();
+		if (PdfTagConstant.AUTO.equals(tagType)) {
+			tagType = PdfTagConstant.P;
+		}
+		return tagType;
 	}
 
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/CellArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/CellArea.java
@@ -17,14 +17,17 @@ package org.eclipse.birt.report.engine.nLayout.area.impl;
 import java.awt.Color;
 
 import org.eclipse.birt.core.exception.BirtException;
+import org.eclipse.birt.report.engine.content.IBandContent;
 import org.eclipse.birt.report.engine.content.ICellContent;
 import org.eclipse.birt.report.engine.content.IContent;
 import org.eclipse.birt.report.engine.content.IStyle;
 import org.eclipse.birt.report.engine.content.impl.ReportContent;
+import org.eclipse.birt.report.engine.content.impl.RowContent;
 import org.eclipse.birt.report.engine.css.engine.StyleConstants;
 import org.eclipse.birt.report.engine.executor.ExecutionContext;
 import org.eclipse.birt.report.engine.layout.pdf.util.PropertyUtil;
 import org.eclipse.birt.report.engine.nLayout.LayoutContext;
+import org.eclipse.birt.report.engine.nLayout.PdfTagConstant;
 import org.eclipse.birt.report.engine.nLayout.area.IContainerArea;
 import org.eclipse.birt.report.engine.nLayout.area.style.BackgroundImageInfo;
 import org.eclipse.birt.report.engine.nLayout.area.style.BoxStyle;
@@ -350,6 +353,29 @@ public class CellArea extends BlockContainerArea implements IContainerArea {
 			cell.setHeight(currentBP + getOffsetY() + localProperties.getPaddingBottom());
 		}
 		return cell;
+	}
+
+	@Override
+	public String getTagType() {
+		String tagType = super.getTagType();
+		if (PdfTagConstant.AUTO.equals(tagType)) {
+			tagType = PdfTagConstant.TD;
+			// In a table row, either TH or TD depending on the row.
+			// In a grid row, no tag at all is used.
+			RowArea row = (RowArea) getParent();
+			if (row.getTableArea().isGridDesign()) {
+				tagType = null;
+			} else {
+				RowContent rowContent = (RowContent)row.getContent();
+				if (rowContent.getBand() != null) {
+					int bandType = rowContent.getBand().getBandType();
+					if (bandType == IBandContent.BAND_HEADER || bandType == IBandContent.BAND_GROUP_HEADER) {
+						tagType = PdfTagConstant.TH;
+					}
+				}
+			}
+		}
+		return tagType;
 	}
 
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/ContainerArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/ContainerArea.java
@@ -47,6 +47,7 @@ import org.w3c.dom.css.CSSPrimitiveValue;
 import org.w3c.dom.css.CSSValue;
 
 import com.lowagie.text.Image;
+import com.lowagie.text.pdf.PdfStructureElement;
 
 /**
  *
@@ -97,7 +98,151 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 
 	protected transient boolean isInInlineStacking = false;
 
+	/**
+	 * It seems as if this variable is no longer used. I cannot find any place where
+	 * it is actually read, except in a cloning constructor.
+	 */
 	protected transient boolean first = true;
+
+	/**
+	 * This is needed for split tracking in PDF/UA. For example, if a table is
+	 * longer than one page, it must be a single table in the tag structure
+	 * nevertheless, and the table element on the next page must be marked as an
+	 * artifact.
+	 *
+	 * @since 4.19
+	 *
+	 */
+	public static class SplitTrackingData {
+		public SplitTrackingData() {
+		};
+
+		public ContainerArea firstPart = null;
+		public short partNumber = 1;
+		public short lastPartNumber = 1; // This is only defined for the first part (when partNumber is 1).
+		public boolean artifact = false;
+	}
+
+	/**
+	 * Split tracking data is only present if a split actually occurs and we
+	 * generate tagged PDF output, to save memory.
+	 */
+	protected transient SplitTrackingData splitTracking = null;
+
+	/**
+	 * Mark this area is a paging artifact.
+	 */
+	public void setArtifact() {
+		if (splitTracking == null) {
+			splitTracking = new SplitTrackingData();
+			splitTracking.artifact = true;
+		}
+	}
+
+	/**
+	 * Is this a paging artifact or not?
+	 *
+	 * @return true if is a paging artifact.
+	 */
+	public boolean isArtifact() {
+		if (splitTracking == null) {
+			return false;
+		}
+		return splitTracking.artifact;
+	}
+
+	/**
+	 * Track the split. Link to the first part, increment the last part number and
+	 * set the partNumber.
+	 *
+	 * Note: previousPart was just created.
+	 *
+	 * Some parts of the tracking data are stored in the firstPart, while others are
+	 * stored in the current area.
+	 *
+	 */
+	protected void setPreviousPart(ContainerArea previousPart) {
+		if (splitTracking == null) {
+			splitTracking = new SplitTrackingData();
+		}
+		previousPart.splitTracking = new SplitTrackingData();
+		if (splitTracking.partNumber == 1) {
+			splitTracking.firstPart = previousPart;
+		} else {
+			previousPart.splitTracking.firstPart = splitTracking.firstPart;
+		}
+		previousPart.splitTracking.partNumber = splitTracking.firstPart.splitTracking.lastPartNumber;
+		splitTracking.firstPart.splitTracking.lastPartNumber++;
+		splitTracking.partNumber = splitTracking.firstPart.splitTracking.lastPartNumber;
+	}
+
+	/**
+	 * @return true if this Area is not split at all or if it is the first part of
+	 *         the split areas sequence.
+	 */
+	public boolean isFirstPart() {
+		if (splitTracking == null) {
+			return true;
+		}
+		return splitTracking.partNumber == 1;
+	}
+
+	/**
+	 * This links to the first part of the split sequence.
+	 *
+	 * @return First area of the split sequence, or null if this is already the
+	 *         first area (or not split at all).
+	 */
+	public ContainerArea getFirstPart() {
+		if (splitTracking == null) {
+			return null;
+		}
+		return splitTracking.firstPart;
+	}
+
+	/**
+	 * Get the number of the last part of the split sequence. This is equal to split
+	 * sequence length.
+	 *
+	 * @return a natural number.
+	 */
+	public short getLastPartNumber() {
+		if (splitTracking == null) {
+			return 1;
+		}
+		return splitTracking.lastPartNumber;
+	}
+
+	PdfStructureElement structureElement;
+
+	/**
+	 * The PDF structure element (that is, a node inside the tag structure tree).
+	 *
+	 * This is only defined for the first part of the split sequence.
+	 *
+	 * @return The structure element, or null if not called for the first part of
+	 *         the split sequence.
+	 */
+	public PdfStructureElement getStructureElement() {
+		return structureElement;
+	}
+
+	/**
+	 * Set the PDF structure element (that is, a node inside the tag structure
+	 * tree).
+	 *
+	 * @param structureElement a PDF structure element, derived from the PDF tag
+	 *                         type.
+	 * @throws BirtException if not called for the first part of the split sequence.
+	 */
+	public void setStructureElement(PdfStructureElement structureElement) throws BirtException {
+		if (!isFirstPart()) {
+			throw new BirtException("Can only store a PdfStructureElement for the first part of a split Area");
+
+		}
+		this.structureElement = structureElement;
+	}
+
 	protected transient boolean finished = false;
 
 	protected CSSValue pageBreakAfter = null;
@@ -470,20 +615,31 @@ public abstract class ContainerArea extends AbstractArea implements IContainerAr
 	public abstract void initialize() throws BirtException;
 
 	/**
-	 * Split container lines
+	 * Split container lines.
+	 *
+	 * This method need better documentation. What is its purpose?
 	 *
 	 * @param lineCount
-	 * @return Return the splitted results
+	 * @return Return the split result
 	 * @throws BirtException
 	 */
 	public abstract SplitResult splitLines(int lineCount) throws BirtException;
 
 	/**
-	 * Split container lines
+	 * Try to split the container which does not fit into the current page.
 	 *
-	 * @param height
-	 * @param force
-	 * @return Return the splitted results
+	 * If the container is actually split, then the result status is
+	 * SPLIT_SUCCEED_WITH_PART, and the result container is a new container which
+	 * contains the first part of the split sequence, while this container is
+	 * modified in place to remove that first part.
+	 *
+	 * If we think of this containers content as a List (which is isn't), this is
+	 * logically similar to firtPart = this.content.remove(0);
+	 *
+	 * @param height The remaining page height.
+	 * @param force  If this is true, ignore "page-break-inside: avoid" and
+	 *               "page-break-before: avoid" properties.
+	 * @return The split result.
 	 * @throws BirtException
 	 */
 	public abstract SplitResult split(int height, boolean force) throws BirtException;

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/InlineContainerArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/InlineContainerArea.java
@@ -252,7 +252,7 @@ public class InlineContainerArea extends InlineStackingArea implements IContaine
 		if (generateBy == null) {
 			return "Span";
 			// Hmm... I would also like to just return null, but that results
-			// in an InvalidArgumentException: The structure has kids when rendered.
+			// in an InvalidArgumentException: "The structure has kids" when rendered.
 		}
 		if (generateBy instanceof ITagType) {
 			return ((ITagType) generateBy).getTagType();

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/InlineContainerArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/InlineContainerArea.java
@@ -251,6 +251,8 @@ public class InlineContainerArea extends InlineStackingArea implements IContaine
 		Object generateBy = content.getGenerateBy();
 		if (generateBy == null) {
 			return "Span";
+			// Hmm... I would also like to just return null, but that results
+			// in an InvalidArgumentException: The structure has kids when rendered.
 		}
 		return ((ITagType) generateBy).getTagType();
 	}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/InlineContainerArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/InlineContainerArea.java
@@ -254,7 +254,10 @@ public class InlineContainerArea extends InlineStackingArea implements IContaine
 			// Hmm... I would also like to just return null, but that results
 			// in an InvalidArgumentException: The structure has kids when rendered.
 		}
-		return ((ITagType) generateBy).getTagType();
+		if (generateBy instanceof ITagType) {
+			return ((ITagType) generateBy).getTagType();
+		}
+		return null;
 	}
 
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/RepeatableArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/RepeatableArea.java
@@ -142,7 +142,17 @@ public abstract class RepeatableArea extends BlockContainerArea {
 				}
 			}
 		}
-		return super.split(height, force);
+		SplitResult ret = super.split(height, force);
+		if (ret.status == SplitResult.SPLIT_SUCCEED_WITH_PART) {
+			Iterator<IArea> i = children.iterator();
+			while (i.hasNext()) {
+				ContainerArea area = (ContainerArea) i.next();
+				if (isInRepeatHeader(area) || "Caption".equals(area.getTagType())) {
+					area.setArtifact();
+				}
+			}
+		}
+		return ret;
 	}
 
 	@Override

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/RowArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/RowArea.java
@@ -23,6 +23,7 @@ import org.eclipse.birt.report.engine.content.IStyle;
 import org.eclipse.birt.report.engine.css.engine.value.css.CSSConstants;
 import org.eclipse.birt.report.engine.css.engine.value.css.CSSValueConstants;
 import org.eclipse.birt.report.engine.nLayout.LayoutContext;
+import org.eclipse.birt.report.engine.nLayout.PdfTagConstant;
 import org.eclipse.birt.report.engine.nLayout.area.IArea;
 
 /**
@@ -262,7 +263,11 @@ public class RowArea extends ContainerArea {
 	@Override
 	public SplitResult split(int height, boolean force) throws BirtException {
 		if (force) {
-			return _split(height, force);
+			SplitResult ret = _split(height, force);
+			if (ret.getResult() != null) {
+				setPreviousPart(ret.getResult());
+			}
+			return ret;
 		} else if (isPageBreakInsideAvoid()) {
 			if (isPageBreakBeforeAvoid()) {
 				return SplitResult.BEFORE_AVOID_WITH_NULL;
@@ -271,7 +276,11 @@ public class RowArea extends ContainerArea {
 			needResolveBorder = true;
 			return SplitResult.SUCCEED_WITH_NULL;
 		}
-		return _split(height, force);
+		SplitResult ret = _split(height, force);
+		if (ret.getResult() != null) {
+			setPreviousPart(ret.getResult());
+		}
+		return ret;
 	}
 
 	protected void _splitSpanCell(int height, boolean force) throws BirtException {
@@ -468,6 +477,18 @@ public class RowArea extends ContainerArea {
 				((CellArea) cell).updateBackgroundImage();
 			}
 		}
+	}
+
+	@Override
+	public String getTagType() {
+		String tagType = super.getTagType();
+		if (PdfTagConstant.AUTO.equals(tagType)) {
+			tagType = PdfTagConstant.TR;
+			if (getTableArea().isGridDesign()) {
+				tagType = null;
+			}
+		}
+		return tagType;
 	}
 
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TableArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TableArea.java
@@ -230,8 +230,10 @@ public class TableArea extends RepeatableArea {
 		}
 		ReportContent report = (ReportContent) content.getReportContent();
 		IRowContent row = report.createRowContent();
+		row.setTagType("Caption");
 		row.setParent(content);
 		ICellContent cell = report.createCellContent();
+		cell.setTagType(null);
 		cell.setColSpan(getColumnCount());
 		cell.setColumn(0);
 		StyleDeclaration cstyle = new StyleDeclaration(report.getCSSEngine());
@@ -241,11 +243,13 @@ public class TableArea extends RepeatableArea {
 		cell.setInlineStyle(cstyle);
 		cell.setParent(row);
 		ILabelContent captionLabel = report.createLabelContent();
+		captionLabel.setTagType(null);
 		captionLabel.setParent(cell);
 		captionLabel.setText(caption);
 		StyleDeclaration style = new StyleDeclaration(report.getCSSEngine());
 		style.setProperty(StyleConstants.STYLE_TEXT_ALIGN, CSSValueConstants.CENTER_VALUE);
 		captionLabel.setInlineStyle(style);
+		captionLabel.setTagType(null);
 		RowArea captionRow = new RowArea(this, context, row);
 		captionRow.isDummy = true;
 		captionRow.setParent(this);
@@ -257,7 +261,6 @@ public class TableArea extends RepeatableArea {
 		captionCell.initialize();
 		captionCell.isDummy = true;
 		captionCell.setRowSpan(1);
-		captionRow.children.add(captionCell);
 		BlockTextArea captionText = new BlockTextArea(captionCell, context, captionLabel);
 		captionText.isDummy = true;
 		captionText.layout();
@@ -265,7 +268,6 @@ public class TableArea extends RepeatableArea {
 		captionCell.setContentHeight(h);
 		captionRow.setHeight(captionCell.getAllocatedHeight());
 		captionRow.finished = true;
-		add(captionRow);
 		if (repeatList == null) {
 			repeatList = new ArrayList<AbstractArea>();
 		}
@@ -311,7 +313,7 @@ public class TableArea extends RepeatableArea {
 					InstanceID unresolvedTableIID = unresolvedRow.getTableArea().getContent().getInstanceID();
 					// this iid can be null, because the table may be generated
 					// from HTML2Content.
-					// in this case, they are ignored by unresloved row hint.
+					// in this case, they are ignored by unresolved row hint.
 					// Currently, large HTML text is not supported to be split.
 					if (unresolvedTableIID != null) {
 						pageHintGenerator.addUnresolvedRowHint(unresolvedTableIID.toUniqueString(),

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/toc/TOCBuilder.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/toc/TOCBuilder.java
@@ -75,6 +75,17 @@ public class TOCBuilder implements ITOCConstants {
 		return startEntry(parent, tocValue, bookmark, hiddenFormats, false, elementId);
 	}
 
+	/**
+	 * This method seems to be only used in tests, not in the engine!
+	 *
+	 * @param parent
+	 * @param tocValue
+	 * @param bookmark
+	 * @param elementId
+	 * @return
+	 *
+	 * @deprecated for removal. Use the variant with hiddenFormats argument instead.
+	 */
 	public TOCEntry startEntry(TOCEntry parent, Object tocValue, String bookmark, long elementId) {
 		return startEntry(parent, tocValue, bookmark, null, false, elementId);
 	}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/toc/TOCEntry.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/toc/TOCEntry.java
@@ -44,4 +44,16 @@ public class TOCEntry extends TreeNode {
 		this.treeNode = treeNode;
 	}
 
+	/**
+	 * Returns the nesting level.
+	 *
+	 * @return 0 for the root note, 1 + parent level otherwise.
+	 */
+	public int getLevel() {
+		if (parent == null) {
+			return 0;
+		}
+		return 1 + parent.getLevel();
+	}
+
 }

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/api/elements/table/LayoutTable.java
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/api/elements/table/LayoutTable.java
@@ -108,7 +108,7 @@ public class LayoutTable {
 	}
 
 	/**
-	 * Return a cell element with the given poistion. Uses this method to find cells
+	 * Return a cell element with the given position. Uses this method to find cells
 	 * in Table Header, Detail and Footer slots.
 	 *
 	 * @param slotId the slot index,

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/elements/rom.def
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/elements/rom.def
@@ -695,16 +695,24 @@
   	<Choice displayNameID="Choices.emitterPdfVersion.1.5" name="1.5"/>
   	<Choice displayNameID="Choices.emitterPdfVersion.1.6" name="1.6"/>
   	<Choice displayNameID="Choices.emitterPdfVersion.1.7" name="1.7"/>
+  	<Choice displayNameID="Choices.emitterPdfVersion.2.0" name="2.0"/>
   </ChoiceType>
   <ChoiceType name="emitterPdfConformance">
   	<Choice displayNameID="Choices.emitterPdfConformance.X32002" name="PDF.X32002"/>
   	<Choice displayNameID="Choices.emitterPdfConformance.A1A" name="PDF.A1A"/>
   	<Choice displayNameID="Choices.emitterPdfConformance.A1B" name="PDF.A1B"/>
+  	<Choice displayNameID="Choices.emitterPdfConformance.A2A" name="PDF.A2A"/>
+  	<Choice displayNameID="Choices.emitterPdfConformance.A2B" name="PDF.A2B"/>
+  	<Choice displayNameID="Choices.emitterPdfConformance.A3A" name="PDF.A3A"/>
+  	<Choice displayNameID="Choices.emitterPdfConformance.A3B" name="PDF.A3B"/>
+  	<Choice displayNameID="Choices.emitterPdfConformance.A3U" name="PDF.A3U"/>
+  	<Choice displayNameID="Choices.emitterPdfConformance.A4F" name="PDF.A4F"/>
   	<Choice displayNameID="Choices.emitterPdfConformance.Standard" name="PDF.Standard"/>
   </ChoiceType>
   <ChoiceType name="emitterPdfUAConformance">
-  	<Choice displayNameID="Choices.emitterPdfConformance.UA1" name="PDF.UA-1"/>
-  	<Choice displayNameID="Choices.emitterPdfConformance.Standard" name="PDF.Standard"/>
+  	<Choice displayNameID="Choices.emitterPdfUAConformance.UA1" name="PDF.UA-1"/>
+  	<Choice displayNameID="Choices.emitterPdfUAConformance.UA2" name="PDF.UA-2"/>
+  	<Choice displayNameID="Choices.emitterPdfUAConformance.none" name="none"/>
   </ChoiceType>
   <ChoiceType name="emitterPdfIccColorType">
   	<Choice displayNameID="Choices.emitterPdfIccColorType.rgb" name="RGB"/>
@@ -1919,7 +1927,7 @@
         <Default>PDF.Standard</Default>
       </Property>
       <Property detailType="emitterPdfUAConformance" canInherit="false" displayNameID="Element.ReportDesign.Emitter.pdf.ua.conformance" name="pdfUAConformance" runtimeSettable="false" since="4.18" type="choice" >
-        <Default>PDF.Standard</Default>
+        <Default>none</Default>
       </Property>
       <Property detailType="emitterPdfIccColorType" canInherit="false" displayNameID="Element.ReportDesign.Emitter.pdf.icc.color.type" name="pdfIccColorType" runtimeSettable="false" since="4.17" type="choice" >
 		<Default>RGB</Default>
@@ -2893,7 +2901,7 @@
     <Property displayNameID="Element.Label.helpText" name="helpText" runtimeSettable="false" since="1.0" type="string"/>
     <Property displayNameID="Element.Label.helpTextID" name="helpTextID" since="1.0" type="resourceKey"/>
     <Property displayNameID="Element.Label.tagType" name="tagType" since="4.3" type="string">
-    	<Default>P</Default>
+    	<Default>auto</Default>
     </Property>
     <Method context="startup" displayNameID="Element.Label.onPrepare" name="onPrepare" since="2.0" toolTipID="Element.Label.onPrepare.toolTip">
       <Argument name="this" tagID="Element.Label.onPrepare.this" type="org.eclipse.birt.report.engine.api.script.element.ILabel"/>
@@ -2997,7 +3005,7 @@
     <Property displayNameID="Element.Data.helpTextID" name="helpTextID" since="1.0" type="resourceKey"/>
     <Property detailType="Action" displayNameID="Element.Data.action" isList="true" name="action" runtimeSettable="false" since="1.0" type="structure"/>
     <Property displayNameID="Element.Data.tagType" name="tagType" since="4.3" type="string">
-    	<Default>P</Default>
+    	<Default>auto</Default>
     </Property>
     <Method context="startup" displayNameID="Element.Data.onPrepare" name="onPrepare" since="2.0" toolTipID="Element.Data.onPrepare.toolTip">
       <Argument name="this" tagID="Element.Data.onPrepare.this" type="org.eclipse.birt.report.engine.api.script.element.IDataItem"/>
@@ -3089,7 +3097,7 @@
     	<Default>true</Default>
     </Property>
     <Property displayNameID="Element.Text.tagType" name="tagType" since="4.3" type="string">
-    	<Default>P</Default>
+    	<Default>auto</Default>
     </Property>
     <Method context="startup" displayNameID="Element.Text.onPrepare" name="onPrepare" since="2.0" toolTipID="Element.Text.onPrepare.toolTip">
       <Argument name="this" tagID="Element.Text.onPrepare.this" type="org.eclipse.birt.report.engine.api.script.element.ITextItem"/>
@@ -3502,7 +3510,7 @@
     	<Default>NoChange</Default>
     </Property>
     <Property displayNameID="Element.Row.tagType" name="tagType" since="4.3" type="string">
-    	<Default>TR</Default>
+    	<Default>auto</Default>
     </Property>
     <Property displayNameID="Element.Row.language" name="language" since="4.3" type="string"/>
     <Method context="startup" displayNameID="Element.Row.onPrepare" name="onPrepare" since="2.0" toolTipID="Element.Row.onPrepare.toolTip">
@@ -3558,7 +3566,7 @@
     	<Default>NoChange</Default>
     </Property>
     <Property displayNameID="Element.Cell.tagType" name="tagType" since="4.3" type="string">
-    	<Default>TD</Default>
+    	<Default>auto</Default>
     </Property>
     <Property displayNameID="Element.Cell.language" name="language" since="4.3" type="string"/>
     <Property displayNameID="Element.Cell.altText" name="altText" since="4.3" type="expression"/>
@@ -3796,7 +3804,7 @@
     	<Default>true</Default>
     </Property>
     <Property displayNameID="Element.TextData.tagType" name="tagType" since="4.3" type="string">
-    	<Default>P</Default>
+    	<Default>auto</Default>
     </Property>
 	<Method context="startup" displayNameID="Element.TextData.onPrepare" name="onPrepare" since="2.0" toolTipID="Element.TextData.onPrepare.toolTip">
       <Argument name="this" tagID="Element.TextData.onPrepare.this" type="org.eclipse.birt.report.engine.api.script.element.IDynamicText"/>

--- a/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/i18n/Messages.properties
+++ b/model/org.eclipse.birt.report.model/src/org/eclipse/birt/report/model/i18n/Messages.properties
@@ -764,11 +764,18 @@ Choices.emitterPdfVersion.1.4=Version 1.4
 Choices.emitterPdfVersion.1.5=Version 1.5
 Choices.emitterPdfVersion.1.6=Version 1.6
 Choices.emitterPdfVersion.1.7=Version 1.7
+Choices.emitterPdfVersion.2.0=Version 2.0
 
 #96 emitterPdfConformance
 Choices.emitterPdfConformance.X32002=PDF, X32002
-Choices.emitterPdfConformance.A1A=PDF, A1A
-Choices.emitterPdfConformance.A1B=PDF, A1B
+Choices.emitterPdfConformance.A1A=PDF/A-1a
+Choices.emitterPdfConformance.A1B=PDF/A-1b
+Choices.emitterPdfConformance.A2A=PDF/A-2a
+Choices.emitterPdfConformance.A2B=PDF/A-2b
+Choices.emitterPdfConformance.A3A=PDF/A-3a
+Choices.emitterPdfConformance.A3B=PDF/A-3b
+Choices.emitterPdfConformance.A3U=PDF/A-3u
+Choices.emitterPdfConformance.A4F=PDF/A-4f
 Choices.emitterPdfConformance.Standard=Standard PDF
 
 #97 emitterPdfIccColorType
@@ -780,7 +787,9 @@ Choices.textDecoration.normal=Normal
 Choices.textDecoration.none=None
 
 #99 emitterPdfUAConformance
-Choices.emitterPdfConformance.UA1=PDF/UA-1
+Choices.emitterPdfUAConformance.UA1=PDF/UA-1
+Choices.emitterPdfUAConformance.UA2=PDF/UA-2
+Choices.emitterPdfUAConformance.none=None
 
 ###########################################################
 # Classes


### PR DESCRIPTION
- Added some example PDF/UA reports.
- Add support for declaring newer PDF/A versions.
- Add support for declaring PDF/UA-2.
- Add support for declaring PDF 2.0.
- Use "auto" as default value for tagType property for some report element types to allow automatic context-depending setting as well as explicit setting.
- Support generating "Caption" tag for tables.
- Fix page-break handling of table rows and cells.
- Create corresponding PDF tags for some HTML elements.
- Add hyperlink support.
- Allow creation of a PDF that conforms to PDF/A and PDF/UA at the same time.
- Fixed specifying the document language based on report locale setting.
- Added THead, TBody, TFoot tags for tables.
- Fixed PDF syntax errors (contentByte.setColorStroke was called at wrong place in drawing sequence).
- Removed support for Acrobat Flash.
- Refactored attributes needed for split tracking into a dedicated class.
- Refactoring of some PDF-tag related constants.
- Added or improved some comments.
- Removed some warnings.

I originally developed this  using my hobby account hvbargen over several weeks.