### PR TITLE
DOCX, optimize header & footer handling (#2026)

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/AbstractEmitterImpl.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/AbstractEmitterImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 Actuate Corporation and others
+ * Copyright (c) 2008, 2024, 2025 Actuate Corporation and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -1171,29 +1171,37 @@ public abstract class AbstractEmitterImpl {
 
 	protected void writeSectionInP() throws IOException, BirtException {
 		wordWriter.startSectionInParagraph();
-		writeHeaderFooter();
-		// the border width /8*20 means to convert an eighth of a point to twips.
-		wordWriter.writePageProperties(pageHeight, pageWidth, headerHeight, footerHeight,
-				topMargin + pageTopBorderWidth / 8 * 20, bottomMargin + pageBottomBorderWidth / 8 * 20,
-				leftMargin + pageLeftBorderWidth / 8 * 20, rightMargin + pageRightBorderWidth / 8 * 20,
-				orientation);
-		wordWriter.writePageBorders(previousPage.getComputedStyle(), topMargin, bottomMargin, leftMargin, rightMargin);
+		writeSectionPageProperties();
 		wordWriter.endSectionInParagraph();
 	}
 
 	protected void writeSectionInBody() throws IOException, BirtException {
 		wordWriter.startSection();
-		writeHeaderFooter();
-		wordWriter.writePageProperties(pageHeight, pageWidth, headerHeight, footerHeight,
-				topMargin + pageTopBorderWidth / 8 * 20, bottomMargin + pageBottomBorderWidth / 8 * 20,
-				leftMargin + pageLeftBorderWidth / 8 * 20, rightMargin + pageRightBorderWidth / 8 * 20,
-				orientation);
-		wordWriter.writePageBorders(previousPage.getComputedStyle(), topMargin, bottomMargin, leftMargin, rightMargin);
+		writeSectionPageProperties();
 		wordWriter.endSection();
 	}
 
-	// TOC must not contain space,word may not process TOC with
-	// space
+	protected void writeSectionPageProperties() throws IOException, BirtException {
+		writeHeaderFooter();
+
+		// WPML, header/footer without layout grid:
+		// a recalculation of the "header margin top"/"header margin bottom" is necessary
+		// WPML, borders:
+		// the border width 8*20 means to convert an eighth of a point to twips.
+		int topMarginComputed = topMargin + (this.wrappedTableHeaderFooter ? 0 : headerHeight) + pageTopBorderWidth / 8 * 20;
+		int bottomMarginComputed = bottomMargin + (this.wrappedTableHeaderFooter ? 0 : footerHeight) + pageBottomBorderWidth / 8 * 20;
+		int leftMarginComputed = leftMargin + pageLeftBorderWidth / 8 * 20;
+		int rightMarginComputed = rightMargin + pageRightBorderWidth / 8 * 20;
+
+		int headerHeightComputed = topMargin;
+		int footerHeightComputed = bottomMargin;
+
+		wordWriter.writePageProperties(pageHeight, pageWidth, headerHeightComputed, footerHeightComputed,
+				topMarginComputed, bottomMarginComputed, leftMarginComputed, rightMarginComputed, orientation);
+		wordWriter.writePageBorders(previousPage.getComputedStyle(), topMargin, bottomMargin, leftMargin, rightMargin);
+	}
+		
+	// TOC must not contain space, word may not process TOC with space
 	protected void writeToc(IContent content) {
 		writeToc(content, false);
 	}

--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/writer/AbstractWordXmlWriter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/writer/AbstractWordXmlWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2009, 2024 Actuate Corporation and others
+ * Copyright (c) 2008, 2009, 2024, 2025 Actuate Corporation and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -243,16 +243,16 @@ public abstract class AbstractWordXmlWriter {
 	}
 
 	/**
-	 * Write page properties
+	 * Write page properties for page margin and the header & footer start margin
 	 *
 	 * @param pageHeight   page height
 	 * @param pageWidth    page width
 	 * @param headerHeight header height
 	 * @param footerHeight footer height
-	 * @param topMargin    top margin
-	 * @param bottomMargin bottom margin
-	 * @param leftMargin   left margin
-	 * @param rightMargin  right margin
+	 * @param topMargin    top margin of the page
+	 * @param bottomMargin bottom margin of the page
+	 * @param leftMargin   left margin of the page
+	 * @param rightMargin  right margin of the page
 	 * @param orient       page orientation
 	 */
 	public void writePageProperties(int pageHeight, int pageWidth, int headerHeight, int footerHeight, int topMargin,
@@ -268,8 +268,8 @@ public abstract class AbstractWordXmlWriter {
 		writer.attribute("w:bottom", bottomMargin);
 		writer.attribute("w:left", leftMargin);
 		writer.attribute("w:right", rightMargin);
-		writer.attribute("w:header", topMargin);
-		writer.attribute("w:footer", bottomMargin);
+		writer.attribute("w:header", headerHeight);
+		writer.attribute("w:footer", footerHeight);
 		writer.closeTag("w:pgMar");
 	}
 
@@ -1460,10 +1460,22 @@ public abstract class AbstractWordXmlWriter {
 		return lineId++;
 	}
 
+	/**
+	 * Set the option to wrap the header and footer with an layout grid
+	 *
+	 * @param useWrappedTable true, a wrapped layout grid for header & footer is to
+	 *                        be used
+	 */
 	public void setWrappedTableHeaderFooter(boolean useWrappedTable) {
 		this.wrappedTableHeaderFooter = useWrappedTable;
 	}
 
+	/**
+	 * Get the information whether a wrapped layout grid is to be used for header
+	 * and footer
+	 *
+	 * @return is a wrapped layout grid is to be used for header and footer
+	 */
 	public boolean getWrappedTableHeaderFooter() {
 		return this.wrappedTableHeaderFooter;
 	}


### PR DESCRIPTION
The optimization is for DOCX and the new option of header/footer without layout grid.
For this option the positions of the header and footer will be re-calculated.
The 2 methods `writeSectionInBody()` and `writeSectionInPara()` will use the same logic to handle the header and footer calculation.

The original behavor can be reconfigured very simple with the property register "Advanced" at the property editor on report-level. If the word-option "Use layot grid of header & footer" then the old behavior will be used.