### PR TITLE
Fix docx header issue #2026

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.docx/src/org/eclipse/birt/report/engine/emitter/docx/writer/DocxWriter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.docx/src/org/eclipse/birt/report/engine/emitter/docx/writer/DocxWriter.java
@@ -155,6 +155,10 @@ public class DocxWriter implements IWordWriter {
 		document.endSection();
 	}
 
+	public boolean isFirstSection() {
+		return document.isFirstSection();
+	}
+
 	@Override
 	public void startHeader(boolean showHeaderOnFirst, int headerHeight, int headerWidth) throws IOException {
 		currentComponent = document.createHeader(showHeaderOnFirst, headerHeight, headerWidth,

--- a/engine/org.eclipse.birt.report.engine.emitter.docx/src/org/eclipse/birt/report/engine/emitter/docx/writer/DocxWriter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.docx/src/org/eclipse/birt/report/engine/emitter/docx/writer/DocxWriter.java
@@ -182,9 +182,7 @@ public class DocxWriter implements IWordWriter {
 
 	@Override
 	public void endFooter() {
-		if (currentComponent == null) {
-			// nothing to do.
-		} else {
+		if (currentComponent != null) {
 			currentComponent.end();
 			document.writeFooterReference(currentComponent, false);
 			currentComponent = document;

--- a/engine/org.eclipse.birt.report.engine.emitter.docx/src/org/eclipse/birt/report/engine/emitter/docx/writer/DocxWriter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.docx/src/org/eclipse/birt/report/engine/emitter/docx/writer/DocxWriter.java
@@ -50,8 +50,6 @@ public class DocxWriter implements IWordWriter {
 
 	private boolean rtl = false;
 
-	private boolean showHeaderOnFirst;
-
 	private int wordVersion;
 
 	private String documentLanguage = "en";
@@ -159,29 +157,34 @@ public class DocxWriter implements IWordWriter {
 
 	@Override
 	public void startHeader(boolean showHeaderOnFirst, int headerHeight, int headerWidth) throws IOException {
-		currentComponent = document.createHeader(headerHeight, headerWidth, this.wrappedTableHeaderFooter);
+		currentComponent = document.createHeader(showHeaderOnFirst, headerHeight, headerWidth,
+				this.wrappedTableHeaderFooter);
 		currentComponent.start();
-		this.showHeaderOnFirst = showHeaderOnFirst;
 	}
 
 	@Override
 	public void endHeader() {
 		currentComponent.end();
-		document.writeHeaderReference(currentComponent, showHeaderOnFirst);
+		document.writeHeaderReference(currentComponent, false);
 		currentComponent = document;
 	}
 
 	@Override
-	public void startFooter(int footerHeight, int footerWidth) throws IOException {
-		currentComponent = document.createFooter(footerHeight, footerWidth, this.wrappedTableHeaderFooter);
+	public void startFooter(boolean showHeaderOnFirst, int footerHeight, int footerWidth) throws IOException {
+		currentComponent = document.createFooter(showHeaderOnFirst, footerHeight, footerWidth,
+				this.wrappedTableHeaderFooter);
 		currentComponent.start();
 	}
 
 	@Override
 	public void endFooter() {
-		currentComponent.end();
-		document.writeFooterReference(currentComponent);
-		currentComponent = document;
+		if (currentComponent == null) {
+			// nothing to do.
+		} else {
+			currentComponent.end();
+			document.writeFooterReference(currentComponent, false);
+			currentComponent = document;
+		}
 	}
 
 	@Override
@@ -373,5 +376,10 @@ public class DocxWriter implements IWordWriter {
 	@Override
 	public boolean getWrappedTableHeaderFooter() {
 		return this.wrappedTableHeaderFooter;
+	}
+
+	@Override
+	public void writeEmptyElement(String tag) {
+		currentComponent.writeEmptyElement(tag);
 	}
 }

--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/AbstractEmitterImpl.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/AbstractEmitterImpl.java
@@ -1461,10 +1461,11 @@ public abstract class AbstractEmitterImpl {
 		String backgroundWidth = style.getBackgroundWidth();
 
 		SimpleMasterPageDesign master = (SimpleMasterPageDesign) previousPage.getGenerateBy();
+		boolean showHeaderOnFirst = master.isShowHeaderOnFirst();
+		boolean empty = true; 
 		if (previousPage.getPageHeader() != null || backgroundHeight != null || backgroundWidth != null) {
-			wordWriter.startHeader(!master.isShowHeaderOnFirst() && previousPage.getPageNumber() == 1, headerHeight,
-					contentWidth);
-
+			empty = false;
+			wordWriter.startHeader(showHeaderOnFirst, headerHeight, contentWidth);
 			if (backgroundHeight != null || backgroundWidth != null) {
 				String backgroundImageUrl = EmitterUtil.getBackgroundImageUrl(style,
 						reportContent.getDesign().getReportDesign(), reportContext.getAppContext());
@@ -1477,18 +1478,13 @@ public abstract class AbstractEmitterImpl {
 			wordWriter.endHeader();
 		}
 		if (previousPage.getPageFooter() != null) {
-			if (!master.isShowFooterOnLast() && previousPage.getPageNumber() == reportContent.getTotalPage()) {
-				IContent footer = previousPage.getPageFooter();
-				ILabelContent emptyContent = footer.getReportContent().createLabelContent();
-				emptyContent.setText(AbstractEmitterImpl.EMPTY_FOOTER);
-				wordWriter.startFooter(footerHeight, contentWidth);
-				contentVisitor.visit(emptyContent, null);
-				wordWriter.endFooter();
-			} else {
-				wordWriter.startFooter(footerHeight, contentWidth);
-				contentVisitor.visitChildren(previousPage.getPageFooter(), null);
-				wordWriter.endFooter();
-			}
+			empty = false;
+			wordWriter.startFooter(showHeaderOnFirst, footerHeight, contentWidth);
+			contentVisitor.visitChildren(previousPage.getPageFooter(), null);
+			wordWriter.endFooter();
+		}
+		if (!empty && !showHeaderOnFirst) {
+			wordWriter.writeEmptyElement("w:titlePg");
 		}
 	}
 

--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/AbstractEmitterImpl.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/AbstractEmitterImpl.java
@@ -1482,9 +1482,21 @@ public abstract class AbstractEmitterImpl {
 		}
 		if (previousPage.getPageFooter() != null) {
 			empty = false;
-			wordWriter.startFooter(showHeaderOnFirst, footerHeight, contentWidth);
-			contentVisitor.visitChildren(previousPage.getPageFooter(), null);
-			wordWriter.endFooter();
+			// We support showFooterOnLast == false only in separate RunTask and RenderTask.  
+			if (!master.isShowFooterOnLast() &&
+					reportContext.getAppContext().get("EngineTask").getClass().getSimpleName().equals("RenderTask")
+					&& previousPage.getPageNumber() == reportContent.getTotalPage()) {
+				IContent footer = previousPage.getPageFooter();
+				ILabelContent emptyContent = footer.getReportContent().createLabelContent();
+				emptyContent.setText(AbstractEmitterImpl.EMPTY_FOOTER);
+				wordWriter.startFooter(false, footerHeight, contentWidth);
+				contentVisitor.visit(emptyContent, null);
+				wordWriter.endFooter();
+			} else {
+				wordWriter.startFooter(showHeaderOnFirst, footerHeight, contentWidth);
+				contentVisitor.visitChildren(previousPage.getPageFooter(), null);
+				wordWriter.endFooter();
+			}
 		}
 		if (!empty && !showHeaderOnFirst) {
 			wordWriter.writeEmptyElement("w:titlePg");

--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/AbstractEmitterImpl.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/AbstractEmitterImpl.java
@@ -1462,6 +1462,9 @@ public abstract class AbstractEmitterImpl {
 
 		SimpleMasterPageDesign master = (SimpleMasterPageDesign) previousPage.getGenerateBy();
 		boolean showHeaderOnFirst = master.isShowHeaderOnFirst();
+		if (!wordWriter.isFirstSection()) {
+			showHeaderOnFirst = true;
+		}
 		boolean empty = true; 
 		if (previousPage.getPageHeader() != null || backgroundHeight != null || backgroundWidth != null) {
 			empty = false;

--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/IWordWriter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/IWordWriter.java
@@ -318,7 +318,7 @@ public interface IWordWriter {
 	 * @param footerWidth  footer width
 	 * @throws IOException
 	 */
-	void startFooter(int footerHeight, int footerWidth) throws IOException;
+	void startFooter(boolean isFirstPage, int footerHeight, int footerWidth) throws IOException;
 
 	/**
 	 * End footer
@@ -396,4 +396,5 @@ public interface IWordWriter {
 		return true;
 	}
 
+	void writeEmptyElement(String tag);
 }

--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/IWordWriter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/IWordWriter.java
@@ -110,6 +110,16 @@ public interface IWordWriter {
 	void endSection();
 
 	/**
+	 * Get the flag if the writer is still in the first section.
+	 *
+	 * This is initially true and will be false after endSection was called the
+	 * first time.
+	 *
+	 * @return true while in first section, false otherwise.
+	 */
+	boolean isFirstSection();
+
+	/**
 	 *
 	 * Write page property
 	 *
@@ -314,6 +324,7 @@ public interface IWordWriter {
 	/**
 	 * Start footer
 	 *
+	 * @param isFirstPage  true for the first page, otherwise false.
 	 * @param footerHeight footer height
 	 * @param footerWidth  footer width
 	 * @throws IOException
@@ -396,5 +407,11 @@ public interface IWordWriter {
 		return true;
 	}
 
+	/**
+	 * Write an empty XML element.
+	 *
+	 * @param tag XML element name
+	 */
 	void writeEmptyElement(String tag);
+
 }

--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/writer/AbstractWordXmlWriter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/writer/AbstractWordXmlWriter.java
@@ -139,11 +139,28 @@ public abstract class AbstractWordXmlWriter {
 		writer.openTag("w:sectPr");
 	}
 
+	private boolean firstSection = true;
+
+	/**
+	 * @return Returns the firstSection.
+	 */
+	public boolean isFirstSection() {
+		return firstSection;
+	}
+
+	/**
+	 * @param firstSection The firstSection to set.
+	 */
+	public void setFirstSection(boolean firstSection) {
+		this.firstSection = firstSection;
+	}
+
 	/**
 	 * End section
 	 */
 	public void endSection() {
 		writer.closeTag("w:sectPr");
+		setFirstSection(false);
 	}
 
 	protected void drawImageShapeType(int imageId) {
@@ -1480,6 +1497,11 @@ public abstract class AbstractWordXmlWriter {
 		return this.wrappedTableHeaderFooter;
 	}
 
+	/**
+	 * Write an empty XML element
+	 *
+	 * @param tag the XML element name
+	 */
 	public void writeEmptyElement(String tag) {
 		writer.openTag(tag);
 		writer.closeTag(tag);

--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/writer/AbstractWordXmlWriter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/writer/AbstractWordXmlWriter.java
@@ -1479,4 +1479,9 @@ public abstract class AbstractWordXmlWriter {
 	public boolean getWrappedTableHeaderFooter() {
 		return this.wrappedTableHeaderFooter;
 	}
+
+	public void writeEmptyElement(String tag) {
+		writer.openTag(tag);
+		writer.closeTag(tag);
+	}
 }

--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/writer/AbstractWordXmlWriter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/writer/AbstractWordXmlWriter.java
@@ -142,14 +142,20 @@ public abstract class AbstractWordXmlWriter {
 	private boolean firstSection = true;
 
 	/**
-	 * @return Returns the firstSection.
+	 * @return whether we are still in the first section or not.
 	 */
 	public boolean isFirstSection() {
 		return firstSection;
 	}
 
 	/**
-	 * @param firstSection The firstSection to set.
+	 * Set if we are in first section.
+	 *
+	 * Usually only called with a value of false, because we start in the first
+	 * section.
+	 *
+	 * @param firstSection true for first section, false for later sections.
+	 *
 	 */
 	public void setFirstSection(boolean firstSection) {
 		this.firstSection = firstSection;

--- a/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/writer/DocWriter.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.wpml/src/org/eclipse/birt/report/engine/emitter/wpml/writer/DocWriter.java
@@ -474,10 +474,11 @@ public class DocWriter extends AbstractWordXmlWriter implements IWordWriter {
 		writer.closeTag("w:hdr");
 	}
 
+
 	@Override
-	public void startFooter(int footerHeight, int footerWidth) {
+	public void startFooter(boolean isFirstPage, int footerHeight, int footerWidth) {
 		writer.openTag("w:ftr");
-		writer.attribute("w:type", "odd");
+		writer.attribute("w:type", (isFirstPage ? "first" : "odd"));
 		startHeaderFooterContainer(footerHeight, footerWidth);
 	}
 


### PR DESCRIPTION
The showHeaderOnFirst property did not work for the DOCX emitter when using the combined RunAndRenderTask.
That is, the header was shown on the first page even when the property was false).
This PR makes this work.
It works with RunAndRenderTask as well as with separate RunTask and RenderTask.

The related property showFooterOnLast does not work with RunAndRenderTask,
only with separate RunTask and RenderTask.
