### PR TITLE
Add command and key binding for SearchAction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build.log
 /updates/
 /workspace/
 /data/org.eclipse.birt.report.data.oda.jdbc/drivers/*.jar
+notes

--- a/UI/org.eclipse.birt.report.designer.ui.views/src/org/eclipse/birt/report/designer/internal/ui/views/ViewContextMenuProvider.java
+++ b/UI/org.eclipse.birt.report.designer.ui.views/src/org/eclipse/birt/report/designer/internal/ui/views/ViewContextMenuProvider.java
@@ -15,6 +15,7 @@ package org.eclipse.birt.report.designer.internal.ui.views;
 
 import java.util.Iterator;
 
+import org.eclipse.birt.report.designer.internal.ui.command.SearchHandler;
 import org.eclipse.birt.report.designer.internal.ui.util.Policy;
 import org.eclipse.birt.report.designer.ui.ContextMenuProvider;
 import org.eclipse.birt.report.designer.ui.views.ProviderFactory;
@@ -36,7 +37,6 @@ import org.eclipse.ui.IWorkbenchActionConstants;
  *
  */
 public class ViewContextMenuProvider extends ContextMenuProvider {
-
 	/**
 	 * constructor
 	 *
@@ -45,6 +45,7 @@ public class ViewContextMenuProvider extends ContextMenuProvider {
 	 */
 	public ViewContextMenuProvider(ISelectionProvider viewer) {
 		super(viewer);
+		SearchHandler.treeViewer = (TreeViewer) viewer;
 	}
 
 	/**

--- a/UI/org.eclipse.birt.report.designer.ui/plugin.properties
+++ b/UI/org.eclipse.birt.report.designer.ui/plugin.properties
@@ -100,6 +100,7 @@ command.name.28 = reloadCssStyleCommand
 command.name.29 = CopyCellContentsAction
 command.name.30 = CreateChartViewCommand
 command.name.31 = resetImageSizeCommand
+command.name.32 = searchAction
 context.name = reportdesignereditpart.context
 extension-point.name = elementAdapters
 extension-point.name.0 = BIRT Designer Report Item EditPart extension

--- a/UI/org.eclipse.birt.report.designer.ui/plugin.xml
+++ b/UI/org.eclipse.birt.report.designer.ui/plugin.xml
@@ -500,6 +500,11 @@
             id="org.eclipse.birt.report.designer.ui.command.resetImageSizeCommand"
             name="%command.name.31">
       </command>
+      <command
+            defaultHandler="org.eclipse.birt.report.designer.internal.ui.command.SearchHandler"
+            id="org.eclipse.birt.report.designer.ui.command.searchAction"
+            name="%command.name.32">
+      </command>
    </extension>
    <extension
          point="org.eclipse.birt.report.designer.ui.DNDServices">
@@ -876,6 +881,14 @@
                type="org.eclipse.birt.report.designer.internal.ui.dialogs.parameters.IHyperlinkParameterProvider">
          </adapter>
       </adaptable>
+   </extension>
+   <extension
+         point="org.eclipse.ui.bindings">
+      <key
+            commandId="org.eclipse.birt.report.designer.ui.command.searchAction"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+F">
+      </key>
    </extension>
    
 </plugin>

--- a/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/command/SearchHandler.java
+++ b/UI/org.eclipse.birt.report.designer.ui/src/org/eclipse/birt/report/designer/internal/ui/command/SearchHandler.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2004 Actuate Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *
+ * Contributors:
+ *  Actuate Corporation  - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.birt.report.designer.internal.ui.command;
+
+import org.eclipse.birt.report.designer.internal.ui.views.actions.SearchAction;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.jface.viewers.TreeViewer;
+
+/**
+ *
+ */
+
+public class SearchHandler extends SelectionHandler {
+	public static TreeViewer treeViewer = null;
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see
+	 * org.eclipse.core.commands.AbstractHandler#execute(org.eclipse.core.commands.
+	 * ExecutionEvent)
+	 */
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		super.execute(event);
+		SearchAction searchAction = new SearchAction(treeViewer);
+		searchAction.run();
+		return Boolean.TRUE;
+	}
+
+}


### PR DESCRIPTION
In response to Thomas' request for a hotkey I've added a command and key binding for the SearchAction.  I don't like this solution  but I haven't found another way to do it.  It establishes an undesirable dependency from ViewContextMenuProvider to SearchHandler.

In order for SearchAction to work it needs a handle to TreeViewer.  A Command only has access to the Event object when executing and there doesn't appear to be a way to get to the TreeViewer through the Event object.  So I had to create a static variable.   ViewContextMenuProvider is pretty close to where the TreeViewer is instantiated.  Since ViewContextMenuProvider isn't visible from SearchHandler, but SearchHandler is visible from ViewContextMenuProvider, I had create the static variable in SearchHandler and set it in ViewContextMenuProvider.  

Please let me know if there's a better way I could have done this.