### PR TITLE
Ensure that the p2 repository has all available sources

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,7 +146,7 @@ Console: <a href='${env.BUILD_URL}/console'>${env.BUILD_URL}/console</a>
 def void mvn() {
   wrap([$class: 'Xvnc', useXauthority: true]) {
     sh '''
-      export MAVEN_OPTS="-XX:MaxRAMPercentage=30"
+      export MAVEN_OPTS="-XX:MaxRAMPercentage=25"
       mvn \
       clean \
       verify \

--- a/build/org.eclipse.birt.p2updatesite/pom.xml
+++ b/build/org.eclipse.birt.p2updatesite/pom.xml
@@ -41,6 +41,7 @@
 				<version>${tycho.version}</version>
 				<configuration>
 					<includeAllDependencies>true</includeAllDependencies>
+					<includeAllSources>true</includeAllSources>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from BIRT" sequenceNumber="59">
+<target name="Generated from BIRT" sequenceNumber="60">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="bcpg" version="0.0.0"/>
@@ -13,6 +13,7 @@
       <unit id="com.github.jtidy" version="0.0.0"/>
       <unit id="com.github.librepdf.openpdf" version="0.0.0"/>
       <unit id="com.github.virtuald.curvesapi" version="0.0.0"/>
+      <unit id="com.github.weisj.jsvg" version="0.0.0"/>
       <unit id="com.sun.el.javax.el" version="0.0.0"/>
       <unit id="com.zaxxer.sparsebits" version="0.0.0"/>
       <unit id="jakarta.activation-api" version="1.2.2"/>


### PR DESCRIPTION
- Update the target platform.
- Try to build mvn using less RAM to avoid out-of-memory when promoting.