### PR TITLE
Synchronize System.getProperties() access

### DIFF
--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/util/SecurityUtil.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/util/SecurityUtil.java
@@ -22,8 +22,13 @@ public class SecurityUtil {
 		return System.getProperty(name);
 	}
 
+	/**
+	 * Returns a copy of {@link System#getProperties()}
+	 *
+	 * @return a copy of {@link System#getProperties()}
+	 */
 	public static Properties getSystemProperties() {
-		return System.getProperties();
+		return (Properties) System.getProperties().clone();
 	}
 
 	public static ClassLoader setContextClassLoader(final ClassLoader loader) {


### PR DESCRIPTION
Create a copy of the global shared `System.getProperties()` to prevent a `ConcurrentModificationException` from being thrown while iterating in `executionContext.registerBeans(systemProperties)`