### PR TITLE
Workaround no biased locking

### DIFF
--- a/LICENSE-OPENJDK.txt
+++ b/LICENSE-OPENJDK.txt
@@ -1,0 +1,40 @@
+This file contains the licensing terms for portions of this project derived
+from OpenJDK source code, specifically the classes:
+
+- java.io.ByteArrayInputStream
+- java.io.ByteArrayOutputStream
+
+-------------------------------------------------------------------------------
+GNU GENERAL PUBLIC LICENSE
+Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+Full text available at:
+https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+
+-------------------------------------------------------------------------------
+"CLASSPATH" EXCEPTION TO THE GPL
+
+Certain source files distributed by Oracle are subject to the following
+clarification and special exception to the GNU General Public License, version 2:
+
+You may link this library with independent modules to produce an executable,
+regardless of the license terms of these independent modules, and you may copy
+and distribute the resulting executable under terms of your choice, provided
+that you also meet, for each linked independent module, the terms and conditions
+of the license of that module.
+
+An independent module is a module which is not derived from or based on this
+library. If you modify this library, you may extend this exception to your
+version of the library, but you are not obligated to do so. If you do not wish
+to do so, delete this exception statement from your version.
+
+-------------------------------------------------------------------------------
+This project includes modified versions of classes originally from the OpenJDK
+project (https://openjdk.org/), redistributed under the terms of GPLv2 with the
+Classpath Exception.

--- a/core/org.eclipse.birt.core/src/org/eclipse/birt/core/util/IOUtil.java
+++ b/core/org.eclipse.birt.core/src/org/eclipse/birt/core/util/IOUtil.java
@@ -158,10 +158,17 @@ public class IOUtil {
 	 * @throws IOException
 	 */
 	public final static int readInt(InputStream inputStream) throws IOException {
-		int ch1 = inputStream.read();
-		int ch2 = inputStream.read();
-		int ch3 = inputStream.read();
-		int ch4 = inputStream.read();
+		byte[] bytebuffer = new byte[4];
+		int bytesRead = inputStream.read(bytebuffer, 0, 4);
+		if (bytesRead != 4) {
+			throw new EOFException();
+		}
+
+		int ch1 = bytebuffer[0] & 0xFF;
+		int ch2 = bytebuffer[1] & 0xFF;
+		int ch3 = bytebuffer[2] & 0xFF;
+		int ch4 = bytebuffer[3] & 0xFF;
+
 		if (ch1 == -1 || ch2 == -1 || ch3 == -1 || ch4 == -1) {
 			throw new EOFException();
 		}

--- a/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/executor/cache/ResultObjectUtil.java
+++ b/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/executor/cache/ResultObjectUtil.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.birt.data.engine.executor.cache;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -34,6 +32,8 @@ import org.eclipse.birt.core.data.DataTypeUtil;
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.core.util.IOUtil;
 import org.eclipse.birt.data.engine.core.DataException;
+import org.eclipse.birt.data.engine.executor.cache.io.ByteArrayInputStream;
+import org.eclipse.birt.data.engine.executor.cache.io.ByteArrayOutputStream;
 import org.eclipse.birt.data.engine.executor.ResultObject;
 import org.eclipse.birt.data.engine.i18n.ResourceConstants;
 import org.eclipse.birt.data.engine.impl.DataEngineSession;

--- a/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/executor/cache/io/ByteArrayInputStream.java
+++ b/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/executor/cache/io/ByteArrayInputStream.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * Modifications copyright (c) 2025 Your Name or Your Company.
+ *
+ * Modifications:
+ * - Based on java.io.ByteArrayInputStream from OpenJDK.
+ * - Modified to [Remove syncronized blocks to improve performance in single Threaded scenarios].
+ */
+
+package org.eclipse.birt.data.engine.executor.cache.io;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+
+public class ByteArrayInputStream extends InputStream {
+    private static final int MAX_TRANSFER_SIZE = 131072;
+    protected byte[] buf;
+    protected int pos;
+    protected int mark = 0;
+    protected int count;
+
+    public ByteArrayInputStream(byte[] buf) {
+        this.buf = buf;
+        this.pos = 0;
+        this.count = buf.length;
+    }
+
+    public ByteArrayInputStream(byte[] buf, int offset, int length) {
+        this.buf = buf;
+        this.pos = offset;
+        this.count = Math.min(offset + length, buf.length);
+        this.mark = offset;
+    }
+
+    public int read() {
+        return this.pos < this.count ? this.buf[this.pos++] & 255 : -1;
+    }
+
+    public int read(byte[] b, int off, int len) {
+        if (this.pos >= this.count) {
+            return -1;
+        } else {
+            int avail = this.count - this.pos;
+            if (len > avail) {
+                len = avail;
+            }
+
+            if (len <= 0) {
+                return 0;
+            } else {
+                System.arraycopy(this.buf, this.pos, b, off, len);
+                this.pos += len;
+                return len;
+            }
+        }
+    }
+
+    public byte[] readAllBytes() {
+        byte[] result = Arrays.copyOfRange(this.buf, this.pos, this.count);
+        this.pos = this.count;
+        return result;
+    }
+
+    public int readNBytes(byte[] b, int off, int len) {
+        int n = this.read(b, off, len);
+        return n == -1 ? 0 : n;
+    }
+
+    public long transferTo(OutputStream out) throws IOException {
+        int len = this.count - this.pos;
+        if (len > 0) {
+            int nbyte;
+            for(int nwritten = 0; nwritten < len; nwritten += nbyte) {
+                nbyte = Integer.min(len - nwritten, 131072);
+                out.write(this.buf, this.pos, nbyte);
+                this.pos += nbyte;
+            }
+
+            assert this.pos == this.count;
+        }
+
+        return (long)len;
+    }
+
+    public long skip(long n) {
+        long k = (long)(this.count - this.pos);
+        if (n < k) {
+            k = n < 0L ? 0L : n;
+        }
+
+        this.pos += (int)k;
+        return k;
+    }
+
+    public int available() {
+        return this.count - this.pos;
+    }
+
+    public boolean markSupported() {
+        return true;
+    }
+
+    public void mark(int readAheadLimit) {
+        this.mark = this.pos;
+    }
+
+    public void reset() {
+        this.pos = this.mark;
+    }
+
+    public void close() throws IOException {
+    }
+}

--- a/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/executor/cache/io/ByteArrayOutputStream.java
+++ b/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/executor/cache/io/ByteArrayOutputStream.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * Modifications copyright (c) 2025 Your Name or Your Company.
+ *
+ * Modifications:
+ * - Based on java.io.ByteArrayOutputStream from OpenJDK.
+ * - Modified to [Remove syncronized blocks to improve performance in single Threaded scenarios].
+ */
+
+package org.eclipse.birt.data.engine.executor.cache.io;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Objects;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+
+/**
+ * This class implements an output stream in which the data is
+ * written into a byte array. The buffer automatically grows as data
+ * is written to it.
+ * The data can be retrieved using {@code toByteArray()} and
+ * {@code toString()}.
+ * <p>
+ * Closing a {@code ByteArrayOutputStream} has no effect. The methods in
+ * this class can be called after the stream has been closed without
+ * generating an {@code IOException}.
+ *
+ * @author  Arthur van Hoff
+ * @since   1.0
+ */
+
+public class ByteArrayOutputStream extends java.io.OutputStream {
+
+    /**
+     * The buffer where data is stored.
+     */
+    protected byte[] buf;
+
+    /**
+     * The number of valid bytes in the buffer.
+     */
+    protected int count;
+
+    /**
+     * Creates a new {@code ByteArrayOutputStream}. The buffer capacity is
+     * initially 32 bytes, though its size increases if necessary.
+     */
+    public ByteArrayOutputStream() {
+        this(32);
+    }
+
+    /**
+     * Creates a new {@code ByteArrayOutputStream}, with a buffer capacity of
+     * the specified size, in bytes.
+     *
+     * @param  size   the initial size.
+     * @throws IllegalArgumentException if size is negative.
+     */
+    public ByteArrayOutputStream(int size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("Negative initial size: "
+                    + size);
+        }
+        buf = new byte[size];
+    }
+
+    /**
+     * Increases the capacity if necessary to ensure that it can hold
+     * at least the number of elements specified by the minimum
+     * capacity argument.
+     *
+     * @param  minCapacity the desired minimum capacity.
+     * @throws OutOfMemoryError if {@code minCapacity < 0} and
+     * {@code minCapacity - buf.length > 0}.  This is interpreted as a
+     * request for the unsatisfiably large capacity.
+     * {@code (long) Integer.MAX_VALUE + (minCapacity - Integer.MAX_VALUE)}.
+     */
+    private void ensureCapacity(int minCapacity) {
+        // overflow-conscious code
+        int oldCapacity = buf.length;
+        int minGrowth = minCapacity - oldCapacity;
+        if (minGrowth > 0) {
+            buf = Arrays.copyOf(buf, newLength(oldCapacity,
+                    minGrowth, oldCapacity /* preferred growth */));
+        }
+    }
+
+    /**
+     * Writes the specified byte to this {@code ByteArrayOutputStream}.
+     *
+     * @param   b   the byte to be written.
+     */
+    @Override
+    public void write(int b) {
+        ensureCapacity(count + 1);
+        buf[count] = (byte) b;
+        count += 1;
+    }
+
+    /**
+     * Writes {@code len} bytes from the specified byte array
+     * starting at offset {@code off} to this {@code ByteArrayOutputStream}.
+     *
+     * @param   b     {@inheritDoc}
+     * @param   off   {@inheritDoc}
+     * @param   len   {@inheritDoc}
+     * @throws  NullPointerException if {@code b} is {@code null}.
+     * @throws  IndexOutOfBoundsException if {@code off} is negative,
+     * {@code len} is negative, or {@code len} is greater than
+     * {@code b.length - off}
+     */
+    @Override
+    public void write(byte[] b, int off, int len) {
+        ensureCapacity(count + len);
+        System.arraycopy(b, off, buf, count, len);
+        count += len;
+    }
+
+    /**
+     * Writes the complete contents of the specified byte array
+     * to this {@code ByteArrayOutputStream}.
+     *
+     * @apiNote
+     * This method is equivalent to {@link #write(byte[],int,int)
+     * write(b, 0, b.length)}.
+     *
+     * @param   b     the data.
+     * @throws  NullPointerException if {@code b} is {@code null}.
+     * @since   11
+     */
+    public void writeBytes(byte[] b) {
+        write(b, 0, b.length);
+    }
+
+    /**
+     * Writes the complete contents of this {@code ByteArrayOutputStream} to
+     * the specified output stream argument, as if by calling the output
+     * stream's write method using {@code out.write(buf, 0, count)}.
+     *
+     * @param   out   the output stream to which to write the data.
+     * @throws  NullPointerException if {@code out} is {@code null}.
+     * @throws  IOException if an I/O error occurs.
+     */
+    public void writeTo(OutputStream out) throws IOException {
+        out.write(buf, 0, count);
+    }
+
+    /**
+     * Resets the {@code count} field of this {@code ByteArrayOutputStream}
+     * to zero, so that all currently accumulated output in the
+     * output stream is discarded. The output stream can be used again,
+     * reusing the already allocated buffer space.
+     *
+     * @see     java.io.ByteArrayInputStream#count
+     */
+    public void reset() {
+        count = 0;
+    }
+
+    /**
+     * Creates a newly allocated byte array. Its size is the current
+     * size of this output stream and the valid contents of the buffer
+     * have been copied into it.
+     *
+     * @return  the current contents of this output stream, as a byte array.
+     * @see     java.io.ByteArrayOutputStream#size()
+     */
+    public byte[] toByteArray() {
+        return Arrays.copyOf(buf, count);
+    }
+
+    /**
+     * Returns the current size of the buffer.
+     *
+     * @return  the value of the {@code count} field, which is the number
+     *          of valid bytes in this output stream.
+     * @see     java.io.ByteArrayOutputStream#count
+     */
+    public int size() {
+        return count;
+    }
+
+    /**
+     * Converts the buffer's contents into a string decoding bytes using the
+     * default charset. The length of the new {@code String}
+     * is a function of the charset, and hence may not be equal to the
+     * size of the buffer.
+     *
+     * <p> This method always replaces malformed-input and unmappable-character
+     * sequences with the default replacement string for the
+     * default charset. The {@linkplain java.nio.charset.CharsetDecoder}
+     * class should be used when more control over the decoding process is
+     * required.
+     *
+     * @see Charset#defaultCharset()
+     * @return String decoded from the buffer's contents.
+     * @since  1.1
+     */
+    @Override
+    public String toString() {
+        return new String(buf, 0, count);
+    }
+
+    /**
+     * Converts the buffer's contents into a string by decoding the bytes using
+     * the named {@link Charset charset}.
+     *
+     * <p> This method is equivalent to {@code #toString(charset)} that takes a
+     * {@link Charset charset}.
+     *
+     * <p> An invocation of this method of the form
+     *
+     * <pre> {@code
+     *      ByteArrayOutputStream b = ...
+     *      b.toString("UTF-8")
+     *      }
+     * </pre>
+     *
+     * behaves in exactly the same way as the expression
+     *
+     * <pre> {@code
+     *      ByteArrayOutputStream b = ...
+     *      b.toString(StandardCharsets.UTF_8)
+     *      }
+     * </pre>
+     *
+     *
+     * @param  charsetName  the name of a supported
+     *         {@link Charset charset}
+     * @return String decoded from the buffer's contents.
+     * @throws UnsupportedEncodingException
+     *         If the named charset is not supported
+     * @since  1.1
+     */
+    public String toString(String charsetName)
+            throws UnsupportedEncodingException
+    {
+        return new String(buf, 0, count, charsetName);
+    }
+
+    /**
+     * Converts the buffer's contents into a string by decoding the bytes using
+     * the specified {@link Charset charset}. The length of the new
+     * {@code String} is a function of the charset, and hence may not be equal
+     * to the length of the byte array.
+     *
+     * <p> This method always replaces malformed-input and unmappable-character
+     * sequences with the charset's default replacement string. The {@link
+     * java.nio.charset.CharsetDecoder} class should be used when more control
+     * over the decoding process is required.
+     *
+     * @param      charset  the {@linkplain Charset charset}
+     *             to be used to decode the {@code bytes}
+     * @return     String decoded from the buffer's contents.
+     * @since      10
+     */
+    public String toString(Charset charset) {
+        return new String(buf, 0, count, charset);
+    }
+
+    /**
+     * Creates a newly allocated string. Its size is the current size of
+     * the output stream and the valid contents of the buffer have been
+     * copied into it. Each character <i>c</i> in the resulting string is
+     * constructed from the corresponding element <i>b</i> in the byte
+     * array such that:
+     * <blockquote><pre>{@code
+     *     c == (char)(((hibyte & 0xff) << 8) | (b & 0xff))
+     * }</pre></blockquote>
+     *
+     * @deprecated This method does not properly convert bytes into characters.
+     * As of JDK&nbsp;1.1, the preferred way to do this is via the
+     * {@link #toString(String charsetName)} or {@link #toString(Charset charset)}
+     * method, which takes an encoding-name or charset argument,
+     * or the {@code toString()} method, which uses the default charset.
+     *
+     * @param      hibyte    the high byte of each resulting Unicode character.
+     * @return     the current contents of the output stream, as a string.
+     * @see        java.io.ByteArrayOutputStream#size()
+     * @see        java.io.ByteArrayOutputStream#toString(String)
+     * @see        java.io.ByteArrayOutputStream#toString()
+     * @see        Charset#defaultCharset()
+     */
+    @Deprecated
+    public String toString(int hibyte) {
+        return new String(buf, hibyte, 0, count);
+    }
+
+    /**
+     * Closing a {@code ByteArrayOutputStream} has no effect. The methods in
+     * this class can be called after the stream has been closed without
+     * generating an {@code IOException}.
+     */
+    @Override
+    public void close() throws IOException {
+    }
+
+    private static final int SOFT_MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
+
+    public static int newLength(int oldLength, int minGrowth, int prefGrowth) {
+        // preconditions not checked because of inlining
+        // assert oldLength >= 0
+        // assert minGrowth > 0
+
+        int prefLength = oldLength + Math.max(minGrowth, prefGrowth); // might overflow
+        if (0 < prefLength && prefLength <= SOFT_MAX_ARRAY_LENGTH) {
+            return prefLength;
+        } else {
+            // put code cold in a separate method
+            return hugeLength(oldLength, minGrowth);
+        }
+    }
+
+    public static int hugeLength(int oldLength, int minGrowth) {
+        int minLength = oldLength + minGrowth;
+        if (minLength < 0) { // overflow
+            throw new OutOfMemoryError(
+                    "Required array length " + oldLength + " + " + minGrowth + " is too large");
+        } else if (minLength <= SOFT_MAX_ARRAY_LENGTH) {
+            return SOFT_MAX_ARRAY_LENGTH;
+        } else {
+            return minLength;
+        }
+    }
+}


### PR DESCRIPTION
Copy & modify `java.io.BytaArrayInputStream` &  `java.io.BytaArrayOutputStream`. 
Mainly remove the syncronized keyword in an effort to avoid the overhead of the threads waiting when in this case only one thread accesses the object. With this the throughput and overall execution time is slightly more than what it was with jdk 11, but still far better than java 15+.

I think the licensing notice is ok, and also the classpath exception.