### PR TITLE
In ResultObjectUtil use unsynchronized byte array stream variants

### DIFF
--- a/data/org.eclipse.birt.data/META-INF/MANIFEST.MF
+++ b/data/org.eclipse.birt.data/META-INF/MANIFEST.MF
@@ -55,6 +55,8 @@ Export-Package: javax.olap,
  org.eclipse.birt.data.engine.olap.util.filter,
  org.eclipse.birt.data.engine.plugin,
  org.eclipse.birt.data.engine.script
+Import-Package: org.apache.commons.io.input,
+ org.apache.commons.io.output
 Require-Bundle: org.eclipse.birt.core;bundle-version="[4.21.0,5.0.0)";visibility:=reexport,
  org.eclipse.datatools.connectivity.oda.consumer;bundle-version="[3.2.5,4.0.0)";visibility:=reexport,
  org.eclipse.datatools.connectivity.oda.profile;bundle-version="[3.2.7,4.0.0)"

--- a/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/executor/cache/ResultObjectUtil.java
+++ b/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/executor/cache/ResultObjectUtil.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.birt.data.engine.executor.cache;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -29,6 +27,8 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Date;
 
+import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.eclipse.birt.core.data.DataType;
 import org.eclipse.birt.core.data.DataTypeUtil;
 import org.eclipse.birt.core.exception.BirtException;
@@ -127,7 +127,7 @@ public class ResultObjectUtil {
 		int rowLen;
 		byte[] rowDataBytes;
 
-		ByteArrayInputStream bais;
+		UnsynchronizedByteArrayInputStream bais;
 		DataInputStream dis;
 
 		for (int i = 0; i < length; i++) {
@@ -143,7 +143,7 @@ public class ResultObjectUtil {
 				totalSize += readSize;
 			}
 
-			bais = new ByteArrayInputStream(rowDataBytes);
+			bais = new UnsynchronizedByteArrayInputStream.Builder().setByteArray(rowDataBytes).get();
 			dis = new DataInputStream(bais);
 
 			Object[] obs = new Object[columnCount];
@@ -260,7 +260,7 @@ public class ResultObjectUtil {
 	public void writeData(OutputStream bos, IResultObject resultObject) throws IOException, DataException {
 		byte[] rowsDataBytes;
 
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		UnsynchronizedByteArrayOutputStream baos = new UnsynchronizedByteArrayOutputStream.Builder().get();
 		DataOutputStream dos = new DataOutputStream(baos);
 
 		for (int j = 0; j < columnCount; j++) {


### PR DESCRIPTION
- Use org.apache.commons.io.input.UnsynchronizedByteArrayInputStream instead of java.io.ByteArrayInputStream
- Use instead org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream of java.io.ByteArrayOutputStream

https://github.com/eclipse-birt/birt/issues/2202