### PR TITLE
Update to Tycho 4.0.13

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,7 +146,7 @@ Console: <a href='${env.BUILD_URL}/console'>${env.BUILD_URL}/console</a>
 def void mvn() {
   wrap([$class: 'Xvnc', useXauthority: true]) {
     sh '''
-      export MAVEN_OPTS="-XX:MaxRAMPercentage=25"
+      export MAVEN_OPTS="-XX:MaxRAMPercentage=30"
       mvn \
       clean \
       verify \

--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from BIRT" sequenceNumber="65">
+<target name="Generated from BIRT" sequenceNumber="66">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="aQute.libg" version="0.0.0"/>
@@ -137,8 +137,8 @@
       <unit id="org.eclipse.xsd.edit.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.xsd.feature.group" version="0.0.0"/>
       <unit id="org.mongodb.mongo-java-driver" version="0.0.0"/>
-      <unit id="org.mortbay.jasper.apache-el" version="0.0.0"/>
-      <unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
+      <unit id="org.mortbay.jasper.apache-el" version="9.0.107"/>
+      <unit id="org.mortbay.jasper.apache-jsp" version="9.0.107"/>
       <unit id="org.mozilla.rhino" version="0.0.0"/>
       <unit id="org.objectweb.asm.commons" version="0.0.0"/>
       <unit id="org.osgi.namespace.contract" version="0.0.0"/>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<maven-surefire-plugin-version>3.5.0</maven-surefire-plugin-version>
 		<maven-assembly-plugin-version>3.7.1</maven-assembly-plugin-version>
 		<maven-resources-plugin-version>3.3.1</maven-resources-plugin-version>
-		<tycho.version>4.0.12</tycho.version>
+		<tycho.version>4.0.13</tycho.version>
 		<wagon.ssh.version>3.5.3</wagon.ssh.version>
 
 		<build.type>nightly</build.type>


### PR DESCRIPTION
- Use export MAVEN_OPTS="-XX:MaxRAMPercentage=30" to avoid heap space errors creating the update site zip.
- Use regenerated target platform with stricter versions for "org.mortbay.jasper to avoid resolving the 10.x versions.