### PR TITLE
Handle missing units in PPTXUtil.convertCssToEnum more robustly

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.pptx/src/org/eclipse/birt/report/engine/emitter/pptx/util/PPTXUtil.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pptx/src/org/eclipse/birt/report/engine/emitter/pptx/util/PPTXUtil.java
@@ -71,8 +71,14 @@ public class PPTXUtil {
 		if (cssDimension == null || "0".equals(cssDimension)) {
 			return 0;
 		}
-
 		DimensionType dimensionType = DimensionType.parserUnit(cssDimension);
-		return dimensionType != null ? convertToEnums(dimensionType.convertTo(DimensionType.UNITS_PT) * 1000) : 0;
+		if (dimensionType == null) {
+			return 0;
+		}
+		String units = dimensionType.getUnits();
+		if (units == null || units.isBlank()) {
+			return 0;
+		}
+		return convertToEnums(dimensionType.convertTo(DimensionType.UNITS_PT) * 1000);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-birt/birt/issues/2412