### PR TITLE
Use Jetty nightly for 12.1.10

### DIFF
--- a/build/org.eclipse.birt.releng/BIRT.setup
+++ b/build/org.eclipse.birt.releng/BIRT.setup
@@ -514,25 +514,6 @@
       <requirement
           name="slf4j.simple"/>
       <requirement
-          name="cdi.api"
-          optional="true"
-          max="0">
-        <annotation>
-          <detail
-              key="justification">
-            <value>Avoid resolving this IU into the generated target platform</value>
-          </detail>
-        </annotation>
-      </requirement>
-      <requirement
-          name="javax.activation"
-          optional="true"
-          max="0"/>
-      <requirement
-          name="jakarta.xml.bind"
-          optional="true"
-          max="0"/>
-      <requirement
           name="org.apache.logging.log4j.slf4j2.impl"
           optional="true"
           max="0"/>
@@ -556,7 +537,7 @@
         <repository
             url="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest"/>
         <repository
-            url="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/release/latest"/>
+            url="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/nightly/latest"/>
         <repository
             url="https://download.eclipse.org/datatools/updates/milestone/latest"/>
         <repository

--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from BIRT" sequenceNumber="105">
+<target name="Generated from BIRT">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="aQute.libg" version="0.0.0"/>
@@ -152,7 +152,7 @@
       <repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds"/>
       <repository location="https://download.eclipse.org/cbi/updates/license"/>
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest"/>
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/release/latest"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/maven-jetty/nightly/latest"/>
       <repository location="https://download.eclipse.org/datatools/updates/milestone/latest"/>
       <repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/latest"/>
       <repository location="https://download.eclipse.org/tools/gef/classic/nightly/latest"/>


### PR DESCRIPTION
- This won't be releases until after SimRel is complete but is needed because 12.1.9 has a bug that breaks the viewer.
- Remove unnecessary negative requirements from the setup.