### PR TITLE
[Charts/SVG] Only append the hotspot layer when it has child nodes

### DIFF
--- a/chart/org.eclipse.birt.chart.device.svg/src/org/eclipse/birt/chart/device/svg/SVGInteractiveRenderer.java
+++ b/chart/org.eclipse.birt.chart.device.svg/src/org/eclipse/birt/chart/device/svg/SVGInteractiveRenderer.java
@@ -1115,10 +1115,20 @@ public class SVGInteractiveRenderer {
 		mapOnloadAdded.clear();
 	}
 
+	/**
+	 * Returns the layer mapping elements to events.
+	 *
+	 * @return a node with events mapped to elements.
+	 */
 	public Node getHotspotLayer() {
 		return hotspotLayer;
 	}
 
+	/**
+	 * Creates a transparent general node as a layer to map events to SVG elements.
+	 *
+	 * @param dom is the document used to create the element.
+	 */
 	public void createHotspotLayer(Document dom) {
 		hotspotLayer = dom.createElement("g"); //$NON-NLS-1$
 		hotspotLayer.setAttribute("id", "hotSpots"); //$NON-NLS-1$ //$NON-NLS-2$

--- a/chart/org.eclipse.birt.chart.device.svg/src/org/eclipse/birt/chart/device/svg/SVGInteractiveRenderer.java
+++ b/chart/org.eclipse.birt.chart.device.svg/src/org/eclipse/birt/chart/device/svg/SVGInteractiveRenderer.java
@@ -1093,6 +1093,17 @@ public class SVGInteractiveRenderer {
 
 	}
 
+	/**
+	 * Indicates if SVG elements are interactive. Hotspot layer must have child
+	 * nodes if SVG elements are mapped to events.
+	 *
+	 * @return {@code true} if some SVG elements are interactive.
+	 * @see SVGInteractiveRenderer#addInteractivity()
+	 */
+	public boolean isInteractive() {
+		return hotspotLayer != null && hotspotLayer.hasChildNodes();
+	}
+
 	protected void setCursor(Element currentElement, Cursor cursor, String defaultCursor) {
 		setCursorAttribute(currentElement, cursor, defaultCursor);
 	}

--- a/chart/org.eclipse.birt.chart.device.svg/src/org/eclipse/birt/chart/device/svg/SVGRendererImpl.java
+++ b/chart/org.eclipse.birt.chart.device.svg/src/org/eclipse/birt/chart/device/svg/SVGRendererImpl.java
@@ -214,11 +214,15 @@ public class SVGRendererImpl extends SwingRendererImpl {
 		super.after();
 
 		ivRenderer.addInteractivity();
+
 		addScripts();
 		((SVGGraphics2D) _g2d).flush();
 
-		// make sure we add the hotspot layer to the bottom layer of the svg
-		dom.getDocumentElement().appendChild(ivRenderer.getHotspotLayer());
+		// Interactivity must not be used with PDF/A-1 conformance levels
+		if (ivRenderer.isInteractive()) {
+			// make sure we add the hotspot layer to the bottom layer of the svg
+			dom.getDocumentElement().appendChild(ivRenderer.getHotspotLayer());
+		}
 
 		if (oOutputIdentifier instanceof OutputStream) // OUTPUT STREAM
 		{

--- a/chart/org.eclipse.birt.chart.device.svg/src/org/eclipse/birt/chart/device/svg/SVGRendererImpl.java
+++ b/chart/org.eclipse.birt.chart.device.svg/src/org/eclipse/birt/chart/device/svg/SVGRendererImpl.java
@@ -218,7 +218,7 @@ public class SVGRendererImpl extends SwingRendererImpl {
 		addScripts();
 		((SVGGraphics2D) _g2d).flush();
 
-		// Interactivity must not be used with PDF/A-1 conformance levels
+		// The hotspot layer is useless without interactivity
 		if (ivRenderer.isInteractive()) {
 			// make sure we add the hotspot layer to the bottom layer of the svg
 			dom.getDocumentElement().appendChild(ivRenderer.getHotspotLayer());

--- a/chart/org.eclipse.birt.chart.tests/src/org/eclipse/birt/chart/tests/device/DeviceTest.java
+++ b/chart/org.eclipse.birt.chart.tests/src/org/eclipse/birt/chart/tests/device/DeviceTest.java
@@ -16,6 +16,7 @@ package org.eclipse.birt.chart.tests.device;
 
 import org.eclipse.birt.chart.tests.device.render.ImageRenderTest;
 import org.eclipse.birt.chart.tests.device.svg.SVGGradientPaintTest;
+import org.eclipse.birt.chart.tests.device.svg.SVGInteractiveRendererTest;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -27,6 +28,7 @@ public class DeviceTest {
 		// $JUnit-BEGIN$
 		suite.addTest(ImageRenderTest.suite());
 		suite.addTestSuite(SVGGradientPaintTest.class);
+		suite.addTestSuite(SVGInteractiveRendererTest.class);
 
 		// $JUnit-END$
 		return suite;

--- a/chart/org.eclipse.birt.chart.tests/src/org/eclipse/birt/chart/tests/device/svg/SVGInteractiveRendererTest.java
+++ b/chart/org.eclipse.birt.chart.tests/src/org/eclipse/birt/chart/tests/device/svg/SVGInteractiveRendererTest.java
@@ -1,0 +1,113 @@
+package org.eclipse.birt.chart.tests.device.svg;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.eclipse.birt.chart.device.svg.SVGGraphics2D;
+import org.eclipse.birt.chart.device.svg.SVGInteractiveRenderer;
+import org.eclipse.birt.chart.event.InteractionEvent;
+import org.eclipse.birt.chart.event.StructureSource;
+import org.eclipse.birt.chart.model.attribute.ActionType;
+import org.eclipse.birt.chart.model.attribute.ActionValue;
+import org.eclipse.birt.chart.model.attribute.TriggerCondition;
+import org.eclipse.birt.chart.model.attribute.impl.URLValueImpl;
+import org.eclipse.birt.chart.model.data.Action;
+import org.eclipse.birt.chart.model.data.Trigger;
+import org.eclipse.birt.chart.model.data.impl.ActionImpl;
+import org.eclipse.birt.chart.model.data.impl.TriggerImpl;
+import org.eclipse.birt.chart.model.layout.TitleBlock;
+import org.eclipse.birt.chart.model.layout.impl.TitleBlockImpl;
+import org.eclipse.birt.chart.util.SecurityUtil;
+import org.w3c.dom.DOMImplementation;
+import org.w3c.dom.Document;
+import org.w3c.dom.DocumentType;
+import org.w3c.dom.Element;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests {@link SVGInteractiveRenderer} methods.
+ */
+public class SVGInteractiveRendererTest extends TestCase {
+
+	private SVGInteractiveRenderer renderer;
+	private Document document;
+
+	@Override
+	protected void setUp() throws Exception {
+		renderer = new SVGInteractiveRenderer(null);
+	}
+
+	/**
+	 * You must call {@link SVGInteractiveRenderer#createHotspotLayer(Document)}
+	 * before adding interactivity events.
+	 */
+	public void testIsInteractiveWhenHotspotIsNull() {
+		assertFalse(renderer.isInteractive());
+	}
+
+	/**
+	 * An empty hotspot layer is useless in the end, because there is no
+	 * interactivity to render.
+	 *
+	 * @throws ParserConfigurationException if the SVG document creation fails.
+	 */
+	public void testIsInteractiveAfterCreatingHotspot() throws ParserConfigurationException {
+		document = createSVGDocument();
+		renderer.createHotspotLayer(document);
+		assertFalse(renderer.isInteractive());
+	}
+
+	/**
+	 * Creates a new SVG document.
+	 *
+	 * @return a new SVG document.
+	 * @throws ParserConfigurationException if a {@link DocumentBuilder} is
+	 *                                      impossible to create.
+	 */
+	private Document createSVGDocument() throws ParserConfigurationException {
+		final DocumentBuilderFactory documentBuilderFactory = SecurityUtil.newDocumentBuilderFactory();
+		final DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+		final DOMImplementation domImplementation = documentBuilder.getDOMImplementation();
+		final DocumentType documentType = domImplementation.createDocumentType("svg", "-//W3C//DTD SVG 1.0//EN",
+				"http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd");
+		final Document svgDocument = domImplementation.createDocument("http://www.w3.org/2000/svg", "svg",
+				documentType);
+		return svgDocument;
+	}
+
+	/**
+	 * {@link SVGInteractiveRenderer#prepareInteractiveEvent(Element, InteractionEvent, Trigger[])}
+	 * must add an item in cached events.
+	 * {@link SVGInteractiveRenderer#addInteractivity()} will handle those cached
+	 * events and render interactivity.
+	 *
+	 * @throws ParserConfigurationException if the SVG document creation fails.
+	 */
+	public void testIsInteractiveWithAnEvent() throws ParserConfigurationException {
+		document = createSVGDocument();
+		renderer.setSVG2D(new SVGGraphics2D(document));
+		final Element element = document.createElement("a");
+		final InteractionEvent event = new InteractionEvent(
+				StructureSource.createTitle((TitleBlock) TitleBlockImpl.createDefault()));
+		Trigger[] triggers = new Trigger [] {
+				TriggerImpl.create(TriggerCondition.ONCLICK_LITERAL, createURLRedirectAction())
+		};
+		renderer.prepareInteractiveEvent(element, event, triggers);
+		renderer.createHotspotLayer(document);
+		renderer.addInteractivity();
+		assertTrue(renderer.isInteractive());
+	}
+
+	/**
+	 * Creates a URL redirect action.
+	 *
+	 * @return a URL redirect action.
+	 */
+	private Action createURLRedirectAction() {
+		final ActionValue value = URLValueImpl.create("https://eclipse.org", "blank", "parameter", "value", "series");
+		final Action urlRedirectAction = ActionImpl.create(ActionType.URL_REDIRECT_LITERAL, value);
+		return urlRedirectAction;
+	}
+}


### PR DESCRIPTION
This is a quick fix for #2410 which we tested by debugging our report. If we delete the hotspot layer before the rendering step, transparency is avoided and the chart appears on the output document.

## Goals

* Allow to render a chart with Chart Interactivity enabled and no event configured.
* Allow to render a chart with Chart Interactivity disabled in a PDF set to PDF/A-1 conformance.

## Next Steps ?

1. Implement test in `org.eclipse.birt.report.engine.emitter.pdf.PDFSvgEmbeddingTest` to prove the bug
2. Study some other implementation options (`org.eclipse.birt.chart.model.attribute.Interactivity.isEnable()`).