### PR TITLE
#2432 Add missing case in the switch for PDFA3U. Validation is ok cor…

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPageDevice.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPageDevice.java
@@ -1192,6 +1192,9 @@ public class PDFPageDevice implements IPageDevice {
 				case PDFA3B:
 					a1.addConformance("B");
 					break;
+				case PDFA3U:
+					a1.addConformance("U");
+					break;
 				case PDFA4F:
 					a1.addConformance("F");
 				}


### PR DESCRIPTION
Added the missing case. Validation does not complain now and it should fix #2432 
```xml
      <validationReport jobEndStatus="normal" profileName="PDF/A-3u validation profile" statement="PDF file is compliant with Validation Profile requirements." isCompliant="true">
        <details passedRules="148" failedRules="0" passedChecks="26513" failedChecks="0"></details>
      </validationReport>
```