### PR TITLE
Exclude data sets with output parameters from the implicit result cache

### DIFF
--- a/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/api/OutputParameterDataSetCacheTest.java
+++ b/data/org.eclipse.birt.data.tests/test/org/eclipse/birt/data/engine/api/OutputParameterDataSetCacheTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse contributors and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.birt.data.engine.api;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.birt.core.data.DataType;
+import org.eclipse.birt.core.exception.BirtException;
+import org.eclipse.birt.core.framework.PlatformConfig;
+import org.eclipse.birt.data.engine.api.querydefn.Binding;
+import org.eclipse.birt.data.engine.api.querydefn.OdaDataSetDesign;
+import org.eclipse.birt.data.engine.api.querydefn.OdaDataSourceDesign;
+import org.eclipse.birt.data.engine.api.querydefn.ParameterDefinition;
+import org.eclipse.birt.data.engine.api.querydefn.QueryDefinition;
+import org.eclipse.birt.data.engine.api.querydefn.ScriptExpression;
+import org.eclipse.birt.data.engine.impl.DataEngineImpl;
+import org.eclipse.birt.data.engine.impl.IEngineExecutionHints;
+import org.junit.Test;
+
+import testutil.BaseTestCase;
+
+/**
+ * Data sets with output parameters must not be implicitly cached (issue #2440).
+ */
+public class OutputParameterDataSetCacheTest extends BaseTestCase {
+
+	@Test
+	public void testOutputParameterDataSetIsNotImplicitlyCached() throws BirtException {
+		DataEngineContext context = DataEngineContext.newInstance(DataEngineContext.DIRECT_PRESENTATION,
+				this.scriptContext, null, null, null);
+		context.setTmpdir(this.getTempDir());
+		PlatformConfig platformConfig = new PlatformConfig();
+		platformConfig.setTempDir(this.getTempDir());
+		DataEngine dataEngine = DataEngine.newDataEngine(platformConfig, context);
+
+		OdaDataSourceDesign dataSource = new OdaDataSourceDesign("ds");
+		dataSource.setExtensionID("org.eclipse.birt.report.data.oda.jdbc");
+
+		OdaDataSetDesign spDataSet = new OdaDataSetDesign("spWithOutputParam", "ds");
+		spDataSet.setExtensionID("org.eclipse.birt.report.data.oda.jdbc.SPSelectDataSet");
+		spDataSet.setQueryText("{call sp_part_weight(?,?)}");
+		spDataSet.addParameter(new ParameterDefinition("p_part", DataType.INTEGER_TYPE, true, false));
+		spDataSet.addParameter(new ParameterDefinition("p_weight", DataType.INTEGER_TYPE, false, true));
+
+		OdaDataSetDesign plainDataSet = new OdaDataSetDesign("inputOnly", "ds");
+		plainDataSet.setExtensionID("org.eclipse.birt.report.data.oda.jdbc");
+		plainDataSet.setQueryText("select part_no from parts where part_no = ?");
+		plainDataSet.addParameter(new ParameterDefinition("p_part", DataType.INTEGER_TYPE, true, false));
+
+		dataEngine.defineDataSource(dataSource);
+		dataEngine.defineDataSet(spDataSet);
+		dataEngine.defineDataSet(plainDataSet);
+
+		// Two queries per data set make it an implicit-cache candidate.
+		IDataQueryDefinition[] queryDefinitions = new IDataQueryDefinition[4];
+		queryDefinitions[0] = newQuery("spWithOutputParam");
+		queryDefinitions[1] = newQuery("spWithOutputParam");
+		queryDefinitions[2] = newQuery("inputOnly");
+		queryDefinitions[3] = newQuery("inputOnly");
+		dataEngine.registerQueries(queryDefinitions);
+
+		IEngineExecutionHints hints = ((DataEngineImpl) dataEngine).getExecutionHints();
+		assertTrue(hints.needCacheDataSet("inputOnly"));
+		assertFalse(hints.needCacheDataSet("spWithOutputParam"));
+
+		dataEngine.shutdown();
+	}
+
+	private static QueryDefinition newQuery(String dataSetName) throws BirtException {
+		QueryDefinition qd = new QueryDefinition();
+		qd.addBinding(new Binding("column1", new ScriptExpression("dataSetRow[\"part_no\"]", DataType.INTEGER_TYPE)));
+		qd.setDataSetName(dataSetName);
+		return qd;
+	}
+}

--- a/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/impl/EngineExecutionHints.java
+++ b/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/impl/EngineExecutionHints.java
@@ -26,6 +26,7 @@ import org.eclipse.birt.data.engine.api.ICacheable;
 import org.eclipse.birt.data.engine.api.IDataQueryDefinition;
 import org.eclipse.birt.data.engine.api.IOdaDataSetDesign;
 import org.eclipse.birt.data.engine.api.IOdaDataSourceDesign;
+import org.eclipse.birt.data.engine.api.IParameterDefinition;
 import org.eclipse.birt.data.engine.api.IQueryDefinition;
 import org.eclipse.birt.data.engine.api.IScriptDataSetDesign;
 import org.eclipse.birt.data.engine.api.querydefn.BaseDataSetDesign;
@@ -104,6 +105,13 @@ public class EngineExecutionHints implements IEngineExecutionHints {
 				}
 			}
 
+			// The cache stores only rows; a cache hit would return null output parameters.
+			for (Object cachedName : new HashSet(this.cachedDataSetNames)) {
+				if (hasOutputParameter(dataEngine.getDataSetDesign(cachedName.toString()))) {
+					this.cachedDataSetNames.remove(cachedName);
+				}
+			}
+
 			// The query filter's type is Only supported in extension, so data set should
 			// not be cached anymore.
 			for (IDataQueryDefinition query : queryDefns) {
@@ -126,6 +134,18 @@ public class EngineExecutionHints implements IEngineExecutionHints {
 				}
 			}
 		}
+	}
+
+	private static boolean hasOutputParameter(IBaseDataSetDesign dataSet) {
+		if (dataSet == null || dataSet.getParameters() == null) {
+			return false;
+		}
+		for (IParameterDefinition param : dataSet.getParameters()) {
+			if (param.isOutputMode()) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/*


### PR DESCRIPTION
Fixes #2440

### What

A data set that declares output parameters is now excluded from the implicit dataset result cache. After `EngineExecutionHints.populateCachedDataSets` has finalized the cached-candidate set, any data set whose design contains an `IParameterDefinition` with `isOutputMode()` is removed from it - mirroring the existing exclusion pass for extension-only filters directly below.

### Why

The implicit result cache stores only rows. On a cache hit the engine substitutes `dscache.DataSourceQuery`, whose `getOutputParameterValue(int/String)` unconditionally returns `null`, so a stored-procedure data set (`SPSelectDataSet`) re-executed with the same parameter values within one render silently loses its OUT parameter values (rows stay correct). See #2440 for the full analysis and a minimal reproducing report design.

Excluding such a data set from the row cache is behavior-preserving: re-execution returns identical rows, only the caching optimization is lost - and it is required for correctness whenever a consumer reads `outputParams["..."]`.

This targets the implicit cache path only; user-configured caching (`getJVMDataSetCacheConfig`) is not gated by `needCacheDataSet` and is out of scope for this issue.

### Test

`OutputParameterDataSetCacheTest` registers two ODA data sets (one with an output parameter, one input-only control), each referenced by two queries so both become implicit-cache candidates, and asserts via `IEngineExecutionHints.needCacheDataSet` that only the input-only data set stays cached. Verified red/green: the test fails on the unpatched engine (the output-parameter data set is cached) and passes with this change, with the control assertion unaffected.
