### PR TITLE
Centralize DocumentBuilderFactory: CommonUtil.newDocumentBuilderFactory

### DIFF
--- a/build/org.eclipse.birt.build/src/org/eclipse/birt/build/framework/Bundle.java
+++ b/build/org.eclipse.birt.build/src/org/eclipse/birt/build/framework/Bundle.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -193,6 +194,11 @@ public class Bundle {
 			InputStream in = entry.getInputStream();
 			if (in != null) {
 				DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+				factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+				factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true); //$NON-NLS-1$
+				factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false); //$NON-NLS-1$
+				factory.setFeature("http://xml.org/sax/features/external-general-entities", false); //$NON-NLS-1$
+				factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false); //$NON-NLS-1$
 				DocumentBuilder builder = factory.newDocumentBuilder();
 				Document document = builder.parse(in, path);
 				return document;

--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -38,6 +38,7 @@
       <unit id="org.apache.batik.bridge" version="0.0.0"/>
       <unit id="org.apache.batik.codec" version="0.0.0"/>
       <unit id="org.apache.batik.constants" version="0.0.0"/>
+      <unit id="org.apache.batik.css" version="0.0.0"/>
       <unit id="org.apache.batik.dom" version="0.0.0"/>
       <unit id="org.apache.batik.dom.svg" version="0.0.0"/>
       <unit id="org.apache.batik.ext" version="0.0.0"/>

--- a/chart/org.eclipse.birt.chart.device.svg/src/org/eclipse/birt/chart/device/svg/SVGRendererImpl.java
+++ b/chart/org.eclipse.birt.chart.device.svg/src/org/eclipse/birt/chart/device/svg/SVGRendererImpl.java
@@ -26,8 +26,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -66,6 +64,7 @@ import org.eclipse.birt.chart.model.layout.Plot;
 import org.eclipse.birt.chart.model.layout.TitleBlock;
 import org.eclipse.birt.chart.util.PluginSettings;
 import org.eclipse.birt.chart.util.SecurityUtil;
+import org.eclipse.birt.core.util.CommonUtil;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.DocumentType;
@@ -300,11 +299,7 @@ public class SVGRendererImpl extends SwingRendererImpl {
 	 * @throws Exception
 	 */
 	protected Document createSvgDocument() throws Exception {
-		DocumentBuilderFactory factory = SecurityUtil.newDocumentBuilderFactory();
-		DocumentBuilder builder;
-
-		builder = factory.newDocumentBuilder();
-		DOMImplementation domImpl = builder.getDOMImplementation();
+		DOMImplementation domImpl = CommonUtil.newDOMImplementation();
 		DocumentType dType = domImpl.createDocumentType("svg", //$NON-NLS-1$
 				SVG_VERSION, SVG_DTD);
 		Document svgDocument = domImpl.createDocument(XMLNS, "svg", dType); //$NON-NLS-1$

--- a/chart/org.eclipse.birt.chart.engine/src/org/eclipse/birt/chart/util/SecurityUtil.java
+++ b/chart/org.eclipse.birt.chart.engine/src/org/eclipse/birt/chart/util/SecurityUtil.java
@@ -47,6 +47,8 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 
+import org.eclipse.birt.core.util.CommonUtil;
+
 /**
  * Utility class to support application level security policy.
  */
@@ -591,7 +593,10 @@ public class SecurityUtil {
 	 * Instantiate a new DocumentBuilderFactory.
 	 *
 	 * @return Return the new document builder factory
+	 *
+	 * @deprecated use {@link CommonUtil#newDocumentBuilder()}
 	 */
+	@Deprecated(since = "4.25", forRemoval = true)
 	public static DocumentBuilderFactory newDocumentBuilderFactory() {
 
 		DocumentBuilderFactory piTmp0;

--- a/chart/org.eclipse.birt.chart.tests/src/org/eclipse/birt/chart/tests/device/svg/SVGInteractiveRendererTest.java
+++ b/chart/org.eclipse.birt.chart.tests/src/org/eclipse/birt/chart/tests/device/svg/SVGInteractiveRendererTest.java
@@ -10,7 +10,6 @@
 package org.eclipse.birt.chart.tests.device.svg;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.birt.chart.device.svg.SVGGraphics2D;
@@ -27,7 +26,7 @@ import org.eclipse.birt.chart.model.data.impl.ActionImpl;
 import org.eclipse.birt.chart.model.data.impl.TriggerImpl;
 import org.eclipse.birt.chart.model.layout.TitleBlock;
 import org.eclipse.birt.chart.model.layout.impl.TitleBlockImpl;
-import org.eclipse.birt.chart.util.SecurityUtil;
+import org.eclipse.birt.core.util.CommonUtil;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.DocumentType;
@@ -76,9 +75,7 @@ public class SVGInteractiveRendererTest extends TestCase {
 	 *                                      impossible to create.
 	 */
 	private Document createSVGDocument() throws ParserConfigurationException {
-		final DocumentBuilderFactory documentBuilderFactory = SecurityUtil.newDocumentBuilderFactory();
-		final DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-		final DOMImplementation domImplementation = documentBuilder.getDOMImplementation();
+		final DOMImplementation domImplementation = CommonUtil.newDOMImplementation();
 		final DocumentType documentType = domImplementation.createDocumentType("svg", "-//W3C//DTD SVG 1.0//EN",
 				"http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd");
 		final Document svgDocument = domImplementation.createDocument("http://www.w3.org/2000/svg", "svg",

--- a/core/org.eclipse.birt.core/src/org/eclipse/birt/core/framework/jar/BundleLoader.java
+++ b/core/org.eclipse.birt.core/src/org/eclipse/birt/core/framework/jar/BundleLoader.java
@@ -23,10 +23,9 @@ import java.util.Properties;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.eclipse.birt.core.util.CommonUtil;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -120,9 +119,7 @@ public class BundleLoader {
 			return;
 		}
 		try {
-			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-			DocumentBuilder builder = factory.newDocumentBuilder();
-			Document document = builder.parse(in);
+			Document document = CommonUtil.newDocumentBuilder().parse(in);
 
 			Element root = document.getDocumentElement();
 

--- a/core/org.eclipse.birt.core/src/org/eclipse/birt/core/util/CommonUtil.java
+++ b/core/org.eclipse.birt.core/src/org/eclipse/birt/core/util/CommonUtil.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2004-2017 Actuate Corporation.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0/.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *
  * Contributors:
  *  Actuate Corporation  - initial API and implementation
@@ -14,10 +14,14 @@
 
 package org.eclipse.birt.core.util;
 
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import org.w3c.dom.DOMImplementation;
 import org.xml.sax.SAXException;
 
 /**
@@ -27,22 +31,83 @@ import org.xml.sax.SAXException;
 public class CommonUtil {
 
 	/**
-	 * Creates SAX parser and disables XXE
+	 * Instantiate SAX parser and disable XML vectors.
 	 *
-	 * @return new SAX parser
+	 * @return a new SAX parser
 	 * @throws ParserConfigurationException
 	 * @throws SAXException
 	 */
 	public static SAXParser createSAXParser() throws ParserConfigurationException, SAXException {
-
 		SAXParserFactory factory = SAXParserFactory.newInstance();
 		// Disable XML External Entity to avoid hack
+		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 		factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true); //$NON-NLS-1$
 		factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false); //$NON-NLS-1$
 		factory.setFeature("http://xml.org/sax/features/external-general-entities", false); //$NON-NLS-1$
 		factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false); //$NON-NLS-1$
-		SAXParser parser = factory.newSAXParser();
+		return factory.newSAXParser();
+	}
 
-		return parser;
+	/**
+	 * Instantiate a new DocumentBuilderFactory and disable XML vectors.
+	 *
+	 * @return a new document builder factory
+	 *
+	 * @throws ParserConfigurationException
+	 *
+	 * @since 4.25
+	 */
+	public static DocumentBuilderFactory newDocumentBuilderFactory() throws ParserConfigurationException {
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true); //$NON-NLS-1$
+		factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false); //$NON-NLS-1$
+		factory.setFeature("http://xml.org/sax/features/external-general-entities", false); //$NON-NLS-1$
+		factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false); //$NON-NLS-1$
+		return factory;
+	}
+
+	/**
+	 * Instantiate a new DocumentBuilder with disabled XML vectors
+	 *
+	 * @return a new document builder.
+	 *
+	 * @throws ParserConfigurationException
+	 *
+	 * @since 4.25
+	 */
+	public static DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
+		return newDocumentBuilderFactory().newDocumentBuilder();
+	}
+
+	/**
+	 * Instantiate a new DocumentBuilder with disabled XML attack vector and with
+	 * the given namespace awareness.
+	 *
+	 * @param namespaceAware the namespace awareness.
+	 *
+	 * @return a new document builder with the given namespace awareness.
+	 *
+	 * @throws ParserConfigurationException
+	 *
+	 * @since 4.25
+	 */
+	public static DocumentBuilder newDocumentBuilder(boolean namespaceAware) throws ParserConfigurationException {
+		DocumentBuilderFactory factory = newDocumentBuilderFactory();
+		factory.setNamespaceAware(namespaceAware);
+		return factory.newDocumentBuilder();
+	}
+
+	/**
+	 * Instantiate a new {@link DOMImplementation}.
+	 *
+	 * @return a new DOM implementation.
+	 *
+	 * @throws ParserConfigurationException
+	 *
+	 * @since 4.25
+	 */
+	public static DOMImplementation newDOMImplementation() throws ParserConfigurationException {
+		return newDocumentBuilder().getDOMImplementation();
 	}
 }

--- a/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/util/PojoQueryParser.java
+++ b/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/util/PojoQueryParser.java
@@ -22,9 +22,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.eclipse.birt.core.util.CommonUtil;
 import org.eclipse.birt.data.oda.pojo.api.Constants;
 import org.eclipse.birt.data.oda.pojo.i18n.Messages;
 import org.eclipse.birt.data.oda.pojo.querymodel.ClassColumnMappings;
@@ -69,9 +69,6 @@ public class PojoQueryParser {
 		if (query == null) {
 			throw new NullPointerException("query is null"); //$NON-NLS-1$
 		}
-		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-		DocumentBuilder builder = null;
-		Document doc = null;
 		InputStream in = null;
 		try {
 			in = new ByteArrayInputStream(query.getBytes("UTF8")); //$NON-NLS-1$
@@ -80,8 +77,8 @@ public class PojoQueryParser {
 					query), e));
 		}
 		try {
-			builder = dbf.newDocumentBuilder();
-			doc = builder.parse(in);
+			DocumentBuilder builder = CommonUtil.newDocumentBuilder();
+			Document doc = builder.parse(in);
 			Element root = doc.getDocumentElement();
 			if (root == null) {
 				throw new OdaException(Messages.getString("Query.FailedToParse", //$NON-NLS-1$
@@ -107,10 +104,6 @@ public class PojoQueryParser {
 		} catch (ParserConfigurationException | SAXException | IOException e) {
 			throw new OdaException(new Exception(Messages.getString("Query.FailedToParse", //$NON-NLS-1$
 					query), e));
-		} finally {
-			doc = null;
-			builder = null;
-			dbf = null;
 		}
 	}
 

--- a/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/util/PojoQueryWriter.java
+++ b/data/org.eclipse.birt.data.oda.pojo/src/org/eclipse/birt/data/oda/pojo/util/PojoQueryWriter.java
@@ -15,17 +15,15 @@ package org.eclipse.birt.data.oda.pojo.util;
 
 import java.io.StringWriter;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import org.eclipse.birt.core.util.CommonUtil;
 import org.eclipse.birt.data.oda.pojo.api.Constants;
 import org.eclipse.birt.data.oda.pojo.querymodel.IColumnsMapping;
 import org.eclipse.birt.data.oda.pojo.querymodel.PojoQuery;
@@ -41,10 +39,8 @@ public class PojoQueryWriter {
 		if (query == null) {
 			return null;
 		}
-		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 		try {
-			DocumentBuilder builder = factory.newDocumentBuilder();
-			Document doc = builder.newDocument();
+			Document doc = CommonUtil.newDocumentBuilder().newDocument();
 			Element root = doc.createElement(Constants.ELEMENT_ROOT);
 			doc.appendChild(root);
 			if (query.getVersion() != null) {

--- a/engine/org.eclipse.birt.report.engine.emitter.pptx.tests/src/org/eclipse/birt/report/engine/emitter/pptx/tests/TreeVisitorTest.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pptx.tests/src/org/eclipse/birt/report/engine/emitter/pptx/tests/TreeVisitorTest.java
@@ -20,10 +20,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.eclipse.birt.core.util.CommonUtil;
 import org.eclipse.birt.report.engine.emitter.pptx.TreeVisitor;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -35,9 +34,7 @@ public class TreeVisitorTest extends TreeVisitor<String> {
 
 	public TreeNode initTree(String xmldoc) throws ParserConfigurationException, SAXException, IOException {
 		File tree = new File(xmldoc);
-		DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-		DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-		Document doc = dBuilder.parse(tree);
+		Document doc = CommonUtil.newDocumentBuilder().parse(tree);
 		doc.getDocumentElement().normalize();
 		TreeNode parent = new TreeNode(null, 0, doc.getDocumentElement().getNodeName());
 		NodeList nodes = doc.getElementsByTagName("node");

--- a/engine/org.eclipse.birt.report.engine.tests/test/org/eclipse/birt/report/engine/executor/css/HTMLProcessorTest.java
+++ b/engine/org.eclipse.birt.report.engine.tests/test/org/eclipse/birt/report/engine/executor/css/HTMLProcessorTest.java
@@ -16,8 +16,7 @@ package org.eclipse.birt.report.engine.executor.css;
 
 import java.util.HashMap;
 
-import javax.xml.parsers.DocumentBuilderFactory;
-
+import org.eclipse.birt.core.util.CommonUtil;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -62,7 +61,7 @@ public class HTMLProcessorTest extends TestCase {
 	}
 
 	private Document getDomTree() throws Exception {
-		Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+		Document doc = CommonUtil.newDocumentBuilder().newDocument();
 		Element body = doc.createElement("body");
 		doc.appendChild(body);
 		Element iEle = doc.createElement("i");

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/parser/HTMLTextParser.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/parser/HTMLTextParser.java
@@ -26,7 +26,6 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -34,6 +33,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import org.eclipse.birt.core.util.CommonUtil;
 import org.w3c.dom.Comment;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -299,8 +299,7 @@ public class HTMLTextParser {
 
 		private static DocumentBuilder newDocumentBuilder() {
 			try {
-				DocumentBuilder docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-				return docBuilder;
+				return CommonUtil.newDocumentBuilder();
 			} catch (ParserConfigurationException e) {
 				logger.log(Level.SEVERE, e.getMessage(), e);
 				return null;

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/parser/PlainTextParser.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/parser/PlainTextParser.java
@@ -24,8 +24,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.xml.parsers.DocumentBuilderFactory;
-
+import org.eclipse.birt.core.util.CommonUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -61,7 +60,7 @@ public class PlainTextParser {
 	 */
 	private Document parsePlainText(Reader reader) {
 		try {
-			Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+			Document doc = CommonUtil.newDocumentBuilder().newDocument();
 			Element body = doc.createElement("body"); //$NON-NLS-1$
 			doc.appendChild(body);
 

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/parser/ReportDesignWriter.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/parser/ReportDesignWriter.java
@@ -25,13 +25,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
 
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import org.eclipse.birt.core.util.CommonUtil;
 import org.eclipse.birt.report.engine.content.IStyle;
 import org.eclipse.birt.report.engine.css.engine.BIRTPropertyManagerFactory;
 import org.eclipse.birt.report.engine.css.engine.StyleConstants;
@@ -83,7 +83,7 @@ public class ReportDesignWriter {
 	 * @throws Exception
 	 */
 	public void write(OutputStream out, Report report) throws Exception {
-		Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+		Document document = CommonUtil.newDocumentBuilder().newDocument();
 
 		new ReportDumpVisitor(document).createDocument(report);
 

--- a/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/util/DesignFileCompareUtil.java
+++ b/model/org.eclipse.birt.report.model.tests/test/org/eclipse/birt/report/model/util/DesignFileCompareUtil.java
@@ -16,9 +16,7 @@ package org.eclipse.birt.report.model.util;
 import java.io.InputStream;
 import java.util.HashSet;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
+import org.eclipse.birt.core.util.CommonUtil;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -84,14 +82,8 @@ public class DesignFileCompareUtil {
 	}
 
 	private Document getDocumentFromInputStream(InputStream is) throws Exception {
-		DocumentBuilderFactory factory = null;
-		DocumentBuilder builder = null;
-		Document doc = null;
 		try {
-			factory = DocumentBuilderFactory.newInstance();
-			builder = factory.newDocumentBuilder();
-			doc = builder.parse(is);
-			return doc;
+			return CommonUtil.newDocumentBuilder().parse(is);
 		} catch (Exception e) {
 			throw e;
 		}

--- a/model/org.eclipse.birt.report.model/romdoc/src/org/eclipse/birt/doc/legacy/RomImage.java
+++ b/model/org.eclipse.birt.report.model/romdoc/src/org/eclipse/birt/doc/legacy/RomImage.java
@@ -18,8 +18,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
@@ -28,6 +26,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import org.eclipse.birt.core.util.CommonUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -37,10 +36,8 @@ public class RomImage {
 	Document document = null;
 
 	public void open() throws RomException {
-		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 		try {
-			DocumentBuilder builder = factory.newDocumentBuilder();
-			document = builder.parse(new File("orig/rom.def"));
+			document = CommonUtil.newDocumentBuilder().parse(new File("orig/rom.def"));
 		} catch (SAXException sxe) {
 			// Error generated during parsing
 			Exception x = sxe;

--- a/testsuites/org.eclipse.birt.tests.core/src/utility/BaseSmokeTest.java
+++ b/testsuites/org.eclipse.birt.tests.core/src/utility/BaseSmokeTest.java
@@ -18,9 +18,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
+import org.eclipse.birt.core.util.CommonUtil;
 import org.eclipse.birt.report.engine.api.EngineConstants;
 import org.eclipse.birt.report.engine.api.EngineException;
 import org.eclipse.birt.report.engine.api.HTMLRenderContext;
@@ -148,9 +146,7 @@ public abstract class BaseSmokeTest extends EngineCase {
 		domwriter.setCanonical(true);
 
 		// reporting.
-		DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
-		DocumentBuilder builder = builderFactory.newDocumentBuilder();
-		Document doc = builder.newDocument();
+		Document doc = CommonUtil.newDocumentBuilder().newDocument();
 
 		Element testsuite = doc.createElement("testsuite"); //$NON-NLS-1$
 		testsuite.setAttribute("name", getName()); //$NON-NLS-1$

--- a/viewer/org.eclipse.birt.report.viewer.tests/test/org/eclipse/birt/report/viewer/util/SoapTests.java
+++ b/viewer/org.eclipse.birt.report.viewer.tests/test/org/eclipse/birt/report/viewer/util/SoapTests.java
@@ -6,13 +6,13 @@ import java.util.Iterator;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import org.eclipse.birt.core.util.CommonUtil;
 import org.eclipse.birt.report.soapengine.api.GetUpdatedObjects;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -82,11 +82,9 @@ public class SoapTests {
 		InputSource inputSource = new InputSource(new StringReader(xml));
 
 		// JAXB unmarshal
-		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-		dbf.setNamespaceAware(true);
-		Document doc = dbf.newDocumentBuilder().parse(inputSource);
+		Document doc = CommonUtil.newDocumentBuilder(true).parse(inputSource);
 
-// XPath na GetUpdatedObjects
+		// XPath and GetUpdatedObjects
 		XPath xpath = XPathFactory.newInstance().newXPath();
 		xpath.setNamespaceContext(new NamespaceContext() {
 			@Override

--- a/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/servlet/BirtSoapParser.java
+++ b/viewer/org.eclipse.birt.report.viewer/birt/WEB-INF/classes/org/eclipse/birt/report/servlet/BirtSoapParser.java
@@ -6,7 +6,6 @@ import java.util.Iterator;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.xpath.XPath;
@@ -14,6 +13,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import org.eclipse.birt.core.util.CommonUtil;
 import org.eclipse.birt.report.soapengine.api.GetUpdatedObjects;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -48,9 +48,7 @@ public class BirtSoapParser {
 		try (InputStream is = request.getInputStream()) {
 
 			// JAXB unmarshal
-			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-			dbf.setNamespaceAware(true);
-			Document doc = dbf.newDocumentBuilder().parse(is);
+			Document doc = CommonUtil.newDocumentBuilder(true).parse(is);
 
 			// XPath to GetUpdatedObjects
 			XPath xpath = XPathFactory.newInstance().newXPath();


### PR DESCRIPTION
- Disable XML attack vectors by default in CommonUtil.newDocumentBuilderFactory much like we already do in CommonUtil.createSAXParser().
- Use this along with additional convenience methods throughout the framework, where applicable.