### PR TITLE
PDF/UA Add support for open-only and close-only tags and for no tag

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/PdfRenderTest.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/PdfRenderTest.java
@@ -23,7 +23,7 @@ import org.eclipse.birt.report.engine.api.PDFRenderOption;
 public class PdfRenderTest extends EngineCase {
 	public void testRenderReport() throws Exception {
 		String thePackage = "test/org/eclipse/birt/report/engine/emitter/pdf/";
-		String[] designs = { "issue-2429", "issue-2445", "issue-2446" };
+		String[] designs = { "issue-2429", "issue-2445", "issue-2446", "issue-2454" };
 		String suffix = ".rptdesign";
 		PDFRenderOption options = new PDFRenderOption();
 		options.setOutputFormat("pdf");

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/issue-2454.rptdesign
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/issue-2454.rptdesign
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.27" id="1">
+    <property name="author">Henning von Bargen</property>
+    <property name="createdBy">Eclipse BIRT Designer Version 4.25.0.qualifier Build &lt;@BUILD@></property>
+    <property name="language">English</property>
+    <text-property name="title">BIRT Issue 2429</text-property>
+    <property name="units">mm</property>
+    <property name="iconFile">/templates/blank_report.gif</property>
+    <property name="bidiLayoutOrientation">ltr</property>
+    <property name="imageDPI">96</property>
+    <property name="locale">en_US</property>
+    <property name="pdfVersion">1.7</property>
+    <property name="pdfConformance">PDF.A3B</property>
+    <property name="pdfUAConformance">PDF.UA-1</property>
+    <property name="pdfaFontFallback">test/org/eclipse/birt/report/engine/emitter/pdf/fonts/NotoSans-Regular.ttf</property>
+    <property name="pdfaFontCidEmbed">false</property>
+    <property name="pdfaDocumentTitleEmbed">true</property>
+    <styles>
+        <style name="report" id="11479">
+            <property name="fontFamily">"Noto Sans"</property>
+        </style>
+    </styles>
+    <page-setup>
+        <simple-master-page name="NewSimpleMasterPage" id="11478">
+            <property name="type">a4</property>
+        </simple-master-page>
+    </page-setup>
+    <body>
+        <label id="11511">
+            <text-property name="text">This report demonstrates open-only and close-only PDF tags and the "none" PDF tag. It also uses the NonStruct tag.</text-property>
+        </label>
+        <grid id="11512">
+            <property name="tagType">none</property>
+            <column id="11513">
+                <property name="width">20mm</property>
+            </column>
+            <column id="11514"/>
+            <column id="11515">
+                <property name="width">20mm</property>
+            </column>
+            <column id="11516"/>
+            <column id="11517">
+                <property name="width">20mm</property>
+            </column>
+            <column id="11518"/>
+            <row id="11519">
+                <property name="tagType">H1</property>
+                <cell id="11520">
+                    <property name="colSpan">6</property>
+                    <property name="rowSpan">1</property>
+                    <property name="tagType">none</property>
+                    <label id="11540">
+                        <property name="fontWeight">bold</property>
+                        <text-property name="text">Acronyms</text-property>
+                        <property name="tagType">NonStruct</property>
+                    </label>
+                </cell>
+            </row>
+            <row id="11526">
+                <property name="tagType">&lt;L</property>
+                <cell id="11527">
+                    <property name="tagType">&lt;LI</property>
+                    <label id="11541">
+                        <text-property name="text">ABBR1</text-property>
+                        <property name="tagType">Lbl</property>
+                    </label>
+                </cell>
+                <cell id="11528">
+                    <property name="tagType">LI></property>
+                    <label id="11547">
+                        <text-property name="text">Explanation for Abbreviation 1</text-property>
+                        <property name="tagType">LBody</property>
+                    </label>
+                </cell>
+                <cell id="11529">
+                    <property name="tagType">&lt;LI</property>
+                    <label id="11542">
+                        <text-property name="text">ABBR2</text-property>
+                        <property name="tagType">Lbl</property>
+                    </label>
+                </cell>
+                <cell id="11530">
+                    <property name="tagType">LI></property>
+                    <label id="11548">
+                        <text-property name="text">Explanation 2</text-property>
+                        <property name="tagType">LBody</property>
+                    </label>
+                </cell>
+                <cell id="11531">
+                    <property name="tagType">&lt;LI</property>
+                    <label id="11543">
+                        <text-property name="text">ABBR3</text-property>
+                        <property name="tagType">Lbl</property>
+                    </label>
+                </cell>
+                <cell id="11532">
+                    <property name="tagType">LI></property>
+                    <label id="11549">
+                        <text-property name="text">Explanation 3</text-property>
+                        <property name="tagType">LBody</property>
+                    </label>
+                </cell>
+            </row>
+            <row id="11533">
+                <property name="tagType">L></property>
+                <cell id="11534">
+                    <property name="tagType">&lt;LI</property>
+                    <label id="11544">
+                        <text-property name="text">ABBR4</text-property>
+                        <property name="tagType">Lbl</property>
+                    </label>
+                </cell>
+                <cell id="11535">
+                    <property name="tagType">LI></property>
+                    <label id="11550">
+                        <text-property name="text">Explanation 4</text-property>
+                        <property name="tagType">LBody</property>
+                    </label>
+                </cell>
+                <cell id="11536">
+                    <property name="tagType">&lt;LI</property>
+                    <label id="11545">
+                        <text-property name="text">ABBR5</text-property>
+                        <property name="tagType">Lbl</property>
+                    </label>
+                </cell>
+                <cell id="11537">
+                    <property name="tagType">LI></property>
+                    <label id="11551">
+                        <text-property name="text">Explanation 5</text-property>
+                        <property name="tagType">LBody</property>
+                    </label>
+                </cell>
+                <cell id="11538">
+                    <property name="tagType">&lt;LI</property>
+                    <label id="11546">
+                        <text-property name="text">ABBR6</text-property>
+                        <property name="tagType">Lbl</property>
+                    </label>
+                </cell>
+                <cell id="11539">
+                    <property name="tagType">LI></property>
+                    <label id="11552">
+                        <text-property name="text">Explanation 6</text-property>
+                        <property name="tagType">LBody</property>
+                    </label>
+                </cell>
+            </row>
+        </grid>
+    </body>
+</report>

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPageDevice.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPageDevice.java
@@ -1427,7 +1427,17 @@ public class PDFPageDevice implements IPageDevice {
 			return;
 		}
 		PdfDictionary properties = null;
+		if (tagType.startsWith("<")) {
+			// open tag, strip <
+			tagType = tagType.substring(1, tagType.length());
+		}
+		if (tagType.endsWith(">")) {
+			// close tag, do not use here
+			return;
+		}
 		switch (tagType) {
+		case PdfTag.NONE:
+			break;
 		case PdfTag.AUTO:
 			System.err.println("TODO: auto TagType found for area: " + area);
 			break;
@@ -1701,6 +1711,14 @@ public class PDFPageDevice implements IPageDevice {
 		if (!writer.isTagged() || tagType == null) {
 			return;
 		}
+		if (tagType.startsWith("<")) {
+			// open tag, do not use here
+			return;
+		}
+		if (tagType.endsWith(">")) {
+			// close tag, strip >
+			tagType = tagType.substring(0, tagType.length() - 1);
+		}
 		if ("pageHeader".equals(tagType)) {
 			currentPage.endArtifact();
 		} else if ("pageFooter".equals(tagType)) {
@@ -1710,6 +1728,8 @@ public class PDFPageDevice implements IPageDevice {
 		} else if (PdfTag.ARTIFACT.equals(tagType)) {
 			currentPage.endArtifact();
 		} else if (currentPage.isInArtifact()) {
+			// do nothing
+		} else if (PdfTag.NONE.equals(tagType)) {
 			// do nothing
 		} else {
 			if (structureCurrentNode == null) {

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PdfTag.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PdfTag.java
@@ -47,4 +47,12 @@ public final class PdfTag {
 	 * @since 4.25
 	 */
 	public static final String ARTIFACT = "artifact";
+
+	/**
+	 * Explicitly do NOT generate a tag. This is not an official PDF tag.
+	 * 
+	 * @since 4.25
+	 * 
+	 */
+	public static final String NONE = "none";
 }


### PR DESCRIPTION
Examples:
Open-only tag: <LI
Close-only tag: LI>
No tag: none

Fixes https://github.com/eclipse-birt/birt/issues/2454