### PR TITLE
PDF/UA: If a data item/label contains newlines, close/reopen its PDF tag

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/issue-2446.rptdesign
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/issue-2446.rptdesign
@@ -64,7 +64,9 @@
                 </structure>
             </list-property>
             <xml-property name="queryText"><![CDATA[select 'Bikes are hot!
-Our bikes are the hottest!!!' as text
+And this is a longer line with some more text which should wrap automatically. 123
+45 Our bikes are the hottest!!!
+Supercalifragilisticexplialidocious' as text
 from productlines
 where productline = 'Motorcycles']]></xml-property>
             <xml-property name="designerValues"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
@@ -112,21 +114,42 @@ where productline = 'Motorcycles']]></xml-property>
         </simple-master-page>
     </page-setup>
     <body>
-        <list id="11482">
-            <property name="dataSet">Productlines</property>
-            <list-property name="boundDataColumns">
-                <structure>
-                    <property name="name">TEXT</property>
-                    <text-property name="displayName">TEXT</text-property>
-                    <expression name="expression" type="javascript">dataSetRow["TEXT"]</expression>
-                    <property name="dataType">string</property>
-                </structure>
-            </list-property>
-            <detail>
-                <data id="11483">
-                    <property name="resultSetColumn">TEXT</property>
-                </data>
-            </detail>
-        </list>
+        <grid id="11484">
+            <column id="11485">
+                <property name="width">50mm</property>
+            </column>
+            <row id="11486">
+                <cell id="11487">
+                    <property name="borderBottomColor">#0000FF</property>
+                    <property name="borderBottomStyle">solid</property>
+                    <property name="borderBottomWidth">thin</property>
+                    <property name="borderLeftColor">#0000FF</property>
+                    <property name="borderLeftStyle">solid</property>
+                    <property name="borderLeftWidth">thin</property>
+                    <property name="borderRightColor">#0000FF</property>
+                    <property name="borderRightStyle">solid</property>
+                    <property name="borderRightWidth">thin</property>
+                    <property name="borderTopColor">#0000FF</property>
+                    <property name="borderTopStyle">solid</property>
+                    <property name="borderTopWidth">thin</property>
+                    <list id="11482">
+                        <property name="dataSet">Productlines</property>
+                        <list-property name="boundDataColumns">
+                            <structure>
+                                <property name="name">TEXT</property>
+                                <text-property name="displayName">TEXT</text-property>
+                                <expression name="expression" type="javascript">dataSetRow["TEXT"]</expression>
+                                <property name="dataType">string</property>
+                            </structure>
+                        </list-property>
+                        <detail>
+                            <data id="11483">
+                                <property name="resultSetColumn">TEXT</property>
+                            </data>
+                        </detail>
+                    </list>
+                </cell>
+            </row>
+        </grid>
     </body>
 </report>

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFRender.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFRender.java
@@ -37,11 +37,12 @@ import org.eclipse.birt.report.engine.nLayout.area.IContainerArea;
 import org.eclipse.birt.report.engine.nLayout.area.IImageArea;
 import org.eclipse.birt.report.engine.nLayout.area.ITemplateArea;
 import org.eclipse.birt.report.engine.nLayout.area.ITextArea;
+import org.eclipse.birt.report.engine.nLayout.area.impl.ContainerArea;
 import org.eclipse.birt.report.engine.nLayout.area.impl.InlineTextArea;
 import org.eclipse.birt.report.engine.nLayout.area.impl.TableArea;
+import org.eclipse.birt.report.engine.nLayout.area.impl.TextArea;
 import org.eclipse.birt.report.engine.nLayout.area.style.TextStyle;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
-
 import org.openpdf.text.pdf.PdfAnnotation;
 import org.openpdf.text.pdf.PdfArray;
 import org.openpdf.text.pdf.PdfDictionary;
@@ -119,6 +120,25 @@ public class PDFRender extends PageDeviceRender {
 
 	@Override
 	public void visitText(ITextArea textArea) {
+
+		if (textArea instanceof TextArea) {
+			final TextArea ta = (TextArea) textArea;
+			if (ta.isLastInLine() && ta.isLineBreak() && "".equals(ta.getText())) {
+				final PDFPageDevice p = (PDFPageDevice) pageDevice;
+				ContainerArea parent = ta.getParent(); // Usually a TextLineArea
+				while (parent != null && parent.getTagType() == null) {
+					parent = parent.getParent(); // Usually a BlockTextArea
+				}
+				if (parent != null) {
+					final String parentTag = parent.getTagType();
+					if (parentTag != null) {
+						p.closeTag(parentTag, parent);
+						p.openTag(parentTag, parent);
+					}
+				}
+			}
+		}
+
 		IHyperlinkAction hlAction = textArea.getAction();
 		if (null != hlAction) {
 			currentPageDevice.openTag(PdfTag.LINK, textArea);

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TextLineArea.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/nLayout/area/impl/TextLineArea.java
@@ -78,9 +78,4 @@ public class TextLineArea extends LineArea {
 		return true;
 	}
 
-	@Override
-	public String getTagType() {
-		final String tag = super.getTagType();
-		return (tag != null) ? tag : "Span";
-	}
 }


### PR DESCRIPTION
Eg if it the tag is "P" and the text is "12\n34", this results in the tag structure
    
    "<P>12</P><P>34</P>".

Fixes https://github.com/eclipse-birt/birt/issues/2446.