### PR TITLE
Use collator in AggregationAccessor.compare

### DIFF
--- a/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/olap/cursor/AggregationAccessor.java
+++ b/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/olap/cursor/AggregationAccessor.java
@@ -36,6 +36,8 @@ import org.eclipse.birt.olap.OLAPException;
 import org.eclipse.birt.olap.cursor.DimensionCursor;
 import org.eclipse.birt.olap.cursor.EdgeCursor;
 
+import com.ibm.icu.text.Collator;
+
 /**
  * This class is to access all aggregation value's according to its result set
  * ID and its index. Aggregation with same aggrOn level list will be assigned
@@ -589,10 +591,14 @@ public class AggregationAccessor extends Accessor {
 		if (value2 == null) {
 			return 1;
 		}
+		Collator instance = Collator.getInstance();
+		if (value1 instanceof CharSequence && value2 instanceof CharSequence) {
+			return instance.compare(value1, value2);
+		}
 		if (value1 instanceof Comparable) {
 			return ((Comparable) value1).compareTo(value2);
 		}
-		return value1.toString().compareTo(value2.toString());
+		return instance.compare(value1.toString(), value2.toString());
 	}
 
 }


### PR DESCRIPTION
- Use in `com.ibm.icu.text.Collator.getInstance()` in `org.eclipse.birt.data.engine.olap.cursor.AggregationAccessor.compare(Object, Object)` to match what's used by
`org.eclipse.birt.data.engine.api.script.BaseScriptEvalUtil.compare(Object, Object, BaseCompareHints)`.

Fixes https://github.com/eclipse-birt/birt/issues/2443