### PR TITLE
Fix issue 2466: Add support for changing PDF metadata dynamically

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/PdfRenderTest.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/PdfRenderTest.java
@@ -23,7 +23,7 @@ import org.eclipse.birt.report.engine.api.PDFRenderOption;
 public class PdfRenderTest extends EngineCase {
 	public void testRenderReport() throws Exception {
 		String thePackage = "test/org/eclipse/birt/report/engine/emitter/pdf/";
-		String[] designs = { "issue-2429", "issue-2445", "issue-2446", "issue-2454" };
+		String[] designs = { "issue-2429", "issue-2445", "issue-2446", "issue-2454", "issue-2466" };
 		String suffix = ".rptdesign";
 		PDFRenderOption options = new PDFRenderOption();
 		options.setOutputFormat("pdf");

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/issue-2466.rptdesign
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/issue-2466.rptdesign
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.27" id="1">
+    <property name="author">Henning von Bargen</property>
+    <property name="comments">Copyright (c) 2014-2024 Triestram &amp; Partner GmbH</property>
+    <property name="createdBy">Eclipse BIRT Designer Version 4.25.0.qualifier Build &lt;@BUILD@></property>
+    <property name="language">German</property>
+    <text-property name="title">BIRT Issue 2466</text-property>
+    <property name="units">mm</property>
+    <property name="iconFile">/templates/blank_report.gif</property>
+    <property name="bidiLayoutOrientation">ltr</property>
+    <property name="imageDPI">96</property>
+    <property name="locale">de_DE</property>
+    <property name="pdfVersion">1.7</property>
+    <property name="pdfConformance">PDF.A3B</property>
+    <property name="pdfUAConformance">PDF.UA-1</property>
+    <property name="pdfaFontFallback">test/org/eclipse/birt/report/engine/emitter/pdf/fonts/NotoSans-Regular.ttf</property>
+    <property name="pdfaFontCidEmbed">false</property>
+    <property name="pdfaDocumentTitleEmbed">true</property>
+    <data-sources>
+        <oda-data-source extensionID="org.eclipse.birt.report.data.oda.jdbc" name="CM" id="11480">
+            <list-property name="privateDriverProperties">
+                <ex-property>
+                    <name>contentBidiFormatStr</name>
+                    <value>ILYNN</value>
+                </ex-property>
+                <ex-property>
+                    <name>metadataBidiFormatStr</name>
+                    <value>ILYNN</value>
+                </ex-property>
+            </list-property>
+            <property name="odaDriverClass">org.eclipse.birt.report.data.oda.sampledb.Driver</property>
+            <property name="odaURL">jdbc:classicmodels:sampledb</property>
+            <property name="odaUser">ClassicModels</property>
+        </oda-data-source>
+    </data-sources>
+    <data-sets>
+        <oda-data-set extensionID="org.eclipse.birt.report.data.oda.jdbc.JdbcSelectDataSet" name="CM" id="11484">
+            <list-property name="columnHints">
+                <structure>
+                    <property name="columnName">PRODUCTLINE</property>
+                    <text-property name="displayName">PRODUCTLINE</text-property>
+                    <text-property name="heading">PRODUCTLINE</text-property>
+                </structure>
+            </list-property>
+            <structure name="cachedMetaData">
+                <list-property name="resultSet">
+                    <structure>
+                        <property name="position">1</property>
+                        <property name="name">PRODUCTLINE</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                </list-property>
+            </structure>
+            <method name="afterOpen"><![CDATA[java.lang.System.out.println("afterOpen DataSource CM");]]></method>
+            <property name="dataSource">CM</property>
+            <list-property name="resultSet">
+                <structure>
+                    <property name="position">1</property>
+                    <property name="name">PRODUCTLINE</property>
+                    <property name="nativeName">PRODUCTLINE</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+            </list-property>
+            <xml-property name="queryText"><![CDATA[select productline
+from productlines
+order by 1]]></xml-property>
+            <xml-property name="designerValues"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+<model:DesignValues xmlns:design="http://www.eclipse.org/datatools/connectivity/oda/design" xmlns:model="http://www.eclipse.org/birt/report/model/adapter/odaModel">
+  <Version>2.0</Version>
+  <design:ResultSets derivedMetaData="true">
+    <design:resultSetDefinitions>
+      <design:resultSetColumns>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>PRODUCTLINE</design:name>
+              <design:position>1</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>12</design:nativeDataTypeCode>
+            <design:precision>50</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>PRODUCTLINE</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>PRODUCTLINE</design:label>
+            <design:formattingHints>
+              <design:displaySize>50</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+      </design:resultSetColumns>
+      <design:criteria/>
+    </design:resultSetDefinitions>
+  </design:ResultSets>
+</model:DesignValues>]]></xml-property>
+        </oda-data-set>
+    </data-sets>
+    <styles>
+        <style name="report" id="11479">
+            <property name="fontFamily">"Noto Sans"</property>
+        </style>
+    </styles>
+    <page-setup>
+        <simple-master-page name="NewSimpleMasterPage" id="11478">
+            <property name="type">a4</property>
+        </simple-master-page>
+    </page-setup>
+    <body>
+        <label id="11483">
+            <text-property name="text">This report is a test for BIRT issue 2466: We want to modify the PDF title dynamically.</text-property>
+        </label>
+        <text-data id="11485">
+            <property name="dataSet">CM</property>
+            <list-property name="boundDataColumns">
+                <structure>
+                    <property name="name">PRODUCTLINE</property>
+                    <text-property name="displayName">PRODUCTLINE</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["PRODUCTLINE"]</expression>
+                    <property name="dataType">string</property>
+                </structure>
+            </list-property>
+            <expression name="valueExpr">reportContext.getAppContext().put("PDF Title", "Dynamically modified title");&#13;
+reportContext.getAppContext().put("PDF Subject", "Dynamically modified PDF metadata");&#13;
+reportContext.getAppContext().put("PDF Keywords", "PDF Title, PDF Subject, PDF Keywords, PDF Description, PDF Language");&#13;
+reportContext.getAppContext().put("PDF Description", "This report shows how to dynamically change PDF metadata.");&#13;
+reportContext.getAppContext().put("PDF Language", "en-EN");&#13;
+&#13;
+row["PRODUCTLINE"]</expression>
+            <property name="contentType">html</property>
+        </text-data>
+    </body>
+</report>

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPageDevice.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPageDevice.java
@@ -310,8 +310,6 @@ public class PDFPageDevice implements IPageDevice {
 			writer = PdfWriter.getInstance(doc, new BufferedOutputStream(output));
 			EngineResourceHandle handle = new EngineResourceHandle(ULocale.forLocale(context.getLocale()));
 
-			this.userProperties = report.getDesign().getUserProperties();
-
 			// PDF version user property based
 			this.setPdfVersion();
 			// PDF/A & PDF/X conformance user property based
@@ -338,23 +336,9 @@ public class PDFPageDevice implements IPageDevice {
 			String creator = handle.getMessage(MessageConstants.PDF_CREATOR, versionInfo);
 			doc.addCreator(creator);
 
-			if (null != author) {
-				doc.addAuthor(author);
-			}
-			// openPDF 1.3.30: title of PDF/A won't be set correctly,
-			// issue on xmp meta data at "dc:title"
-			if (!this.isPdfAFormat || this.addPdfADocumentTitle) {
-				if (null != title) {
-					doc.addTitle(title);
-				}
-			}
-			if (null != subject) {
-				doc.addSubject(subject);
-				doc.addKeywords(subject);
-			}
-			if (description != null) {
-				doc.addHeader("Description", description);
-			}
+			updateMetadata(title, author, subject, subject, description); // The old behavior is actually to put the
+																			// subject as "subject" and "keywords"
+
 
 			if (this.isPdfUAFormat) {
 				String localeString = report.getDesign().getLocale();
@@ -364,13 +348,7 @@ public class PDFPageDevice implements IPageDevice {
 				Locale locale = Locale.of(localeString);
 				String language = locale.toString();
 				language = language.replace('_', '-'); // 'de_de' is invalid, it should be 'de-DE'.
-				doc.setDocumentLanguage(language);
-				// In order to declare the main language of the document,
-				// we need to use the extraCatalog. That way we don't need to
-				// modify existing OpenPDF source code.
-				PdfDictionary extraCatalog = writer.getExtraCatalog();
-				extraCatalog.put(PdfName.LANG, new PdfString(language, PdfObject.TEXT_UNICODE));
-
+				updateLanguage(language);
 				writer.addViewerPreference(PdfName.DISPLAYDOCTITLE, PdfBoolean.PDFTRUE);
 			}
 
@@ -470,6 +448,41 @@ public class PDFPageDevice implements IPageDevice {
 		}
 	}
 
+	private void updateMetadata(String title, String author, String subject, String keywords, String description) {
+
+		if (null != author) {
+			doc.addAuthor(author);
+		}
+		// openPDF 1.3.30: title of PDF/A won't be set correctly,
+		// issue on xmp meta data at "dc:title"
+		if (null != title) {
+			if (!this.isPdfAFormat || this.addPdfADocumentTitle) {
+				doc.addTitle(title);
+			}
+		}
+		if (null != subject) {
+			doc.addSubject(subject);
+		}
+		if (null != keywords) {
+			doc.addKeywords(keywords);
+		}
+		if (description != null) {
+			doc.addHeader("Description", description);
+		}
+
+	}
+
+	private void updateLanguage(String language) {
+		if (language == null)
+			return;
+		doc.setDocumentLanguage(language);
+		// In order to declare the main language of the document,
+		// we need to use the extraCatalog. That way we don't need to
+		// modify existing OpenPDF source code.
+		PdfDictionary extraCatalog = writer.getExtraCatalog();
+		extraCatalog.put(PdfName.LANG, new PdfString(language, PdfObject.TEXT_UNICODE));
+	}
+
 	/**
 	 * Initialize the attributes for the PDF tag tree structure.
 	 */
@@ -544,8 +557,30 @@ public class PDFPageDevice implements IPageDevice {
 		return imageCache;
 	}
 
+	private String getPDFUserProperty(String name) {
+		Object o = context.getAppContext().getOrDefault(name, null);
+		if (o == null)
+			return null;
+		String s = o.toString();
+		if (s.isEmpty())
+			return null;
+		return s;
+	}
+
 	@Override
 	public void close() throws Exception {
+
+		// Issue 2446: Update metadata again, to allow using DB data for some important
+		// metadata like the title and the document language.
+		String title = getPDFUserProperty("PDF Title");
+		String author = getPDFUserProperty("PDF Author");
+		String subject = getPDFUserProperty("PDF Subject");
+		String keywords = getPDFUserProperty("PDF Keywords");
+		String description = getPDFUserProperty("PDF Description");
+		String language = getPDFUserProperty("PDF Language");
+		updateMetadata(title, author, subject, keywords, description);
+		updateLanguage(language);
+
 		if (!doc.isOpen()) {
 			// to ensure we create a PDF file
 			doc.open();


### PR DESCRIPTION
This PR allows setting some PDF metadata fields during the creation of the report, that is, dynamically.

The following info can be set using `reportContext.getAppContext().put(name, value);`

* "PDF Title"
* "PDF Author"
* "PDF Subject"
* "PDF Keywords"
* "PDF Description"
* "PDF Language"

Using the AppContext for this seems a bit like a code smell.
However, it is easy to access from the JS side and from the emitter.

Using report properties would be cleaner, but I couldn't get it to work, and it is also a bit cumbersome to access from JS anyway.
And I wanted to avoid adding even more special PDF properties to the properties page.

So using the AppContext seemed the lesser evil to me.

I'm not sure about the actual names.
We could also use more technical names like `eclipse.birt.report.emitter.pdf.title` instead of `PDF Title`. 
But would that be better? I don't think so.
Or maybe we could add a sub-map `eclipse.birt.report.emitter.pdf.meta` to the AppContext and then only use `title`, `author` etc. as names in that map.

Fixes issue #2466 