### PR TITLE
Replace iText references with OpenPDF in locale message resources

### DIFF
--- a/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/nls/messages.properties
+++ b/UI/org.eclipse.birt.report.designer.core/src/org/eclipse/birt/report/designer/nls/messages.properties
@@ -961,7 +961,7 @@ designer.preview.preference.updateReportParameter.confirmOption.ignore=&Ignore
 
 designer.preview.previewaction.label.webviewer=View Report in Web Viewer
 designer.preview.previewaction.label=View Report as {0}
-designer.preview.previewaction.ErrorMessage=PDF generation is not enabled since iText is not installed or found.
+designer.preview.previewaction.ErrorMessage=PDF generation is not enabled since OpenPDF is not installed or found.
 designer.preview.previewaction.ErrorMessage.title=Warning
 designer.preview.run.webviewer=In Web Viewer
 designer.preview.run=As {0}

--- a/nl/org.eclipse.birt.report.designer.core.nl/src/org/eclipse/birt/report/designer/nls/messages_de_DE.msg
+++ b/nl/org.eclipse.birt.report.designer.core.nl/src/org/eclipse/birt/report/designer/nls/messages_de_DE.msg
@@ -1470,7 +1470,7 @@ designer.preview.previewaction.label.webviewer=Bericht in Web Viewer anzeigen
 
 designer.preview.previewaction.label=Bericht als {0} anzeigen
 
-designer.preview.previewaction.ErrorMessage=Die PDF-Erzeugung ist nicht aktiviert, da iText weder installiert ist noch gefunden wurde.
+designer.preview.previewaction.ErrorMessage=Die PDF-Erzeugung ist nicht aktiviert, da OpenPDF weder installiert ist noch gefunden wurde.
 
 designer.preview.previewaction.ErrorMessage.title=Warnung
 

--- a/nl/org.eclipse.birt.report.designer.core.nl/src/org/eclipse/birt/report/designer/nls/messages_es_ES.msg
+++ b/nl/org.eclipse.birt.report.designer.core.nl/src/org/eclipse/birt/report/designer/nls/messages_es_ES.msg
@@ -1470,7 +1470,7 @@ designer.preview.previewaction.label.webviewer=Ver informe en Web Viewer
 
 designer.preview.previewaction.label=Ver informe como {0}
 
-designer.preview.previewaction.ErrorMessage=La generación de PDF no está activada ya que no se encuentra iText o no está instalado.
+designer.preview.previewaction.ErrorMessage=La generación de PDF no está activada ya que no se encuentra OpenPDF o no está instalado.
 
 designer.preview.previewaction.ErrorMessage.title=Advertencia
 

--- a/nl/org.eclipse.birt.report.designer.core.nl/src/org/eclipse/birt/report/designer/nls/messages_fr_FR.msg
+++ b/nl/org.eclipse.birt.report.designer.core.nl/src/org/eclipse/birt/report/designer/nls/messages_fr_FR.msg
@@ -1470,7 +1470,7 @@ designer.preview.previewaction.label.webviewer=Afficher l'état dans le visualis
 
 designer.preview.previewaction.label=Afficher l''état au format {0}
 
-designer.preview.previewaction.ErrorMessage=La fonction de génération de PDF n'est pas activée car iText n'est pas installé ou est introuvable.
+designer.preview.previewaction.ErrorMessage=La fonction de génération de PDF n'est pas activée car OpenPDF n'est pas installé ou est introuvable.
 
 designer.preview.previewaction.ErrorMessage.title=Avertissement
 

--- a/nl/org.eclipse.birt.report.designer.core.nl/src/org/eclipse/birt/report/designer/nls/messages_ja_JP.msg
+++ b/nl/org.eclipse.birt.report.designer.core.nl/src/org/eclipse/birt/report/designer/nls/messages_ja_JP.msg
@@ -1470,7 +1470,7 @@ designer.preview.previewaction.label.webviewer=Web ビューアでレポート�
 
 designer.preview.previewaction.label=レポートを {0} として表示する
 
-designer.preview.previewaction.ErrorMessage=iText がインストールされていないか見つからないため、PDF の生成は有効になっていません。
+designer.preview.previewaction.ErrorMessage=OpenPDF がインストールされていないか見つからないため、PDF の生成は有効になっていません。
 
 designer.preview.previewaction.ErrorMessage.title=警告
 

--- a/nl/org.eclipse.birt.report.designer.core.nl/src/org/eclipse/birt/report/designer/nls/messages_ko_KR.msg
+++ b/nl/org.eclipse.birt.report.designer.core.nl/src/org/eclipse/birt/report/designer/nls/messages_ko_KR.msg
@@ -1470,7 +1470,7 @@ designer.preview.previewaction.label.webviewer=웹 뷰어에서 보고서 보기
 
 designer.preview.previewaction.label={0}(으)로 보고서 보기
 
-designer.preview.previewaction.ErrorMessage=iText가 설치되지 않았거나 찾을 수 없어서 PDF 생성 기능을 사용할 수 없습니다.
+designer.preview.previewaction.ErrorMessage=OpenPDF가 설치되지 않았거나 찾을 수 없어서 PDF 생성 기능을 사용할 수 없습니다.
 
 designer.preview.previewaction.ErrorMessage.title=경고
 

--- a/nl/org.eclipse.birt.report.designer.core.nl/src/org/eclipse/birt/report/designer/nls/messages_zh_CN.msg
+++ b/nl/org.eclipse.birt.report.designer.core.nl/src/org/eclipse/birt/report/designer/nls/messages_zh_CN.msg
@@ -1470,7 +1470,7 @@ designer.preview.previewaction.label.webviewer=在 Web 查看器中查看报表
 
 designer.preview.previewaction.label=以 {0} 格式查看报表
 
-designer.preview.previewaction.ErrorMessage=由于未安装或未找到 iText，不支持 PDF 生成。
+designer.preview.previewaction.ErrorMessage=由于未安装或未找到 OpenPDF，不支持 PDF 生成。
 
 designer.preview.previewaction.ErrorMessage.title=警告
 

--- a/nl/org.eclipse.birt.report.engine.nl/src/org/eclipse/birt/report/engine/i18n/Messages_de_DE.msg
+++ b/nl/org.eclipse.birt.report.engine.nl/src/org/eclipse/birt/report/engine/i18n/Messages_de_DE.msg
@@ -182,7 +182,7 @@ Error.ResultsetExtractError = Ergebnis nicht gefunden.
 Error.FailedToInitializeEmitter = Emitter konnte nicht initialisiert werden.
 
 ###########################################################
-PDFCreator = BIRT-Berichtengine {0} mit iText {1}.
+PDFCreator = BIRT-Berichtengine {0}.
 
 ###########################################################
 Error.FlashObjectNotSupported = Berichtobjekte aus Flash-Objekten werden in diesem Berichtformat nicht unterstützt.

--- a/nl/org.eclipse.birt.report.engine.nl/src/org/eclipse/birt/report/engine/i18n/Messages_fr_FR.msg
+++ b/nl/org.eclipse.birt.report.engine.nl/src/org/eclipse/birt/report/engine/i18n/Messages_fr_FR.msg
@@ -182,7 +182,7 @@ Error.ResultsetExtractError = Jeu de résultats introuvable.
 Error.FailedToInitializeEmitter = Echec de l'initialisation de l'émetteur.
 
 ###########################################################
-PDFCreator = Moteur d'états BIRT {0} utilisant iText ({1}).
+PDFCreator = Moteur d'états BIRT {0}.
 
 ###########################################################
 Error.FlashObjectNotSupported = Les éléments d'état d'objet Flash ne sont pas pris en charge par ce format.

--- a/nl/org.eclipse.birt.report.engine.nl/src/org/eclipse/birt/report/engine/i18n/Messages_ja_JP.msg
+++ b/nl/org.eclipse.birt.report.engine.nl/src/org/eclipse/birt/report/engine/i18n/Messages_ja_JP.msg
@@ -182,7 +182,7 @@ Error.ResultsetExtractError = 結果セットが見つかりません。
 Error.FailedToInitializeEmitter = エミッターを初期化できませんでした。
 
 ###########################################################
-PDFCreator = BIRT レポートエンジン {0} (iText {1} を使用)
+PDFCreator = BIRT レポートエンジン {0}
 
 ###########################################################
 Error.FlashObjectNotSupported = Flash オブジェクトのレポート項目は、このレポート形式ではサポートされていません。

--- a/nl/org.eclipse.birt.report.engine.nl/src/org/eclipse/birt/report/engine/i18n/Messages_ko_KR.msg
+++ b/nl/org.eclipse.birt.report.engine.nl/src/org/eclipse/birt/report/engine/i18n/Messages_ko_KR.msg
@@ -182,7 +182,7 @@ Error.ResultsetExtractError = 결과 집합을 찾을 수 없습니다.
 Error.FailedToInitializeEmitter = 이미터를 초기화하지 못했습니다.
 
 ###########################################################
-PDFCreator = iText {1}을(를) 사용하는 BIRT 보고서 엔진 {0}
+PDFCreator = BIRT 보고서 엔진 {0}
 
 ###########################################################
 Error.FlashObjectNotSupported = 플래시 개체 보고서 항목은 이 보고서 형식에서 지원되지 않습니다.

--- a/nl/org.eclipse.birt.report.engine.nl/src/org/eclipse/birt/report/engine/i18n/Messages_zh_CN.msg
+++ b/nl/org.eclipse.birt.report.engine.nl/src/org/eclipse/birt/report/engine/i18n/Messages_zh_CN.msg
@@ -182,7 +182,7 @@ Error.ResultsetExtractError = 找不到结果集。
 Error.FailedToInitializeEmitter = 初始化发射器失败。
 
 ###########################################################
-PDFCreator = 使用 iText {1} 的 BIRT 报表引擎 {0}。
+PDFCreator = BIRT 报表引擎 {0}。
 
 ###########################################################
 Error.FlashObjectNotSupported = 此报表格式不支持 Flash 对象报表项。


### PR DESCRIPTION
Fixes #2467.

## What Changed
Replaced "iText" (the PDF  library BIRT no longer uses) with "OpenPDF" in the message resources that still referenced it - 12 files, 2 message keys:
- `designer.preview.previewaction.ErrorMessage` : base English `message.properties` (UI module) + 6 locale `.msg` sources in `org.eclipse.birt.report.designer.core.nl` (de_DE, es_ES, fr_FR, ja_JP, ko_KR, zh_CN). Plain word substitution.
- `PDFCreator`: 5 locale `.msg` sources in `org.eclipse.birt.report.engine.nl` (de_DE, fr_FR, ja_JP, ko_KR, zh_CN). `es_ES` and base English were already clean.

## Why `.msg`, not  `.properties`
- The `_xx_XX.properties` files under each `.nl` module are generated build output, not source.
- `.nl/pom.xml` deletes them on `clean` and regenerates  them from the `.msg` files via Ant's `native2ascii` on `compile`.
- Each module's `.gitignore` confirms they're untracked.
- So this PR edits the `.msg` sources only; `.properties` regenerate on build as usval.

## Why `PDFCreator` isn't a plain word swap in 5 locales

- The `PDFCreator` pattern has a `{1}` placeholder, but `PDFPageDevice.java`
  only supplies one value now (`versionInfo = { BundleVersionUtil
  .getBundleVersion(...) }` — just the engine version, for `{0}`).
- Any locale still referencing `{1}` was already rendering an unresolved
  literal `{1}` in the PDF's Creator metadata — a pre-existing bug,
  independent of the iText wording.
- Base English and `es_ES` had already dropped the "using iText {1}" clause
  entirely, rather than swap it for an OpenPDF equivalent.
- This PR applies that same fix to the remaining 5 locales, instead of a
  literal find-and-replace that would leave the placeholder bug in place.

## Out of scope (left untouched, deliberately)

- Code comments in `PDFPageDevice.java`, `FontMappingManager.java`, and
  `FontMappingManagerFactory.java` also mention "iText" — per the issue's own
  scope ("all non-java resources"), these weren't touched here.
- `designer.preview.previewaction.ErrorMessage` doesn't appear to be
  referenced anywhere in Java source under that key (checked across `UI/`
  and `engine/`) - may be dead code from when iText/OpenPDF was an optional
  detected jar rather than a bundled dependency. 
 
Worth a separate issue if maintainers want it looked at; the text fix here is correct either way.

## Testing done locally

- Encoding check: decoded each `.msg` file with the encoding declared in
  `nl/pom.xml` (Cp1252/GBK/SJIS/MS949), re-encoded, confirmed an exact
  byte-for-byte round trip.
- `mvn package -DskipTests` — full build succeeded, no `native2ascii`/antrun
  errors.
- Inspected the regenerated `_xx_XX.properties` files: new "OpenPDF" text
  appears correctly `\u`-escaped, no leftover "iText", no dangling `{1}`.
- Rendered a report via the engine API across multiple locales and checked
  the PDF's Creator field directly — confirmed the fix reaches the real
  output. Screenshots below.
- Note: GitHub's web diff view renders these files as mojibake since it
  assumes UTF-8 — the actual files are Cp1252/GBK/SJIS/MS949 as declared
  in `nl/pom.xml`. This is expected and unrelated to the fix; only the
  `iText`→`OpenPDF` word changed on each line (verified by decoding with
  the correct encoding locally before/after editing).  
  
  
<img width="613" height="326" alt="image" src="https://github.com/user-attachments/assets/864d52c3-eed9-4e81-80c2-37b46d1db499" />
<img width="727" height="150" alt="image" src="https://github.com/user-attachments/assets/74ef1d7a-0ae3-46de-8bf6-6b1391a7ab3a" />
