### PR TITLE
Add reportContext.openDataSet() to read data sets from script (#1351)

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/AllTests.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/AllTests.java
@@ -30,6 +30,7 @@ public class AllTests {
 		/* in package: org.eclipse.birt.report.engine.emitter.pdf */
 		suite.addTestSuite(org.eclipse.birt.report.engine.emitter.pdf.PdfRenderTest.class);
 		suite.addTestSuite(org.eclipse.birt.report.engine.emitter.pdf.PdfConcurrentRenderTest.class);
+		suite.addTestSuite(org.eclipse.birt.report.engine.emitter.pdf.OpenDataSetTest.class);
 
 		// $JUnit-END$
 		return suite;

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/OpenDataSetTest.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/OpenDataSetTest.java
@@ -1,0 +1,143 @@
+
+/*******************************************************************************
+ * Copyright (c) 2026 Actuate Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *
+ * Contributors:
+ *  Actuate Corporation  - initial API and implementation (issue #1351)
+ *******************************************************************************/
+package org.eclipse.birt.report.engine.emitter.pdf;
+
+import java.io.File;
+import java.util.List;
+
+import org.eclipse.birt.report.engine.api.IRunAndRenderTask;
+import org.eclipse.birt.report.engine.api.PDFRenderOption;
+
+/**
+ * Covers {@code reportContext.openDataSet(...)} (issue #1351): reading a data
+ * set from a beforeFactory/onPrepare script, before the report is laid out.
+ * <p>
+ * These tests assert on render completion and on engine errors recorded via
+ * {@code task.getErrors()} - script exceptions are caught internally rather
+ * than thrown out of {@code run()}. They do not verify glyph-level PDF content,
+ * since this module has no PDF text extraction available. The actual effect of
+ * a script-driven design change (opendataset-regionconfig.rptdesign: an
+ * onPrepare script reads the first row of "RegionConfig" and rewrites a label's
+ * text with it) was verified manually - see the PR description for the console
+ * output and rendered PDF.
+ */
+public class OpenDataSetTest extends EngineCase {
+
+	private static final String PKG = "test/org/eclipse/birt/report/engine/emitter/pdf/";
+
+	private File outputDir;
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		outputDir = new File(System.getProperty("java.io.tmpdir"), "birt-opendataset-test");
+		outputDir.mkdirs();
+	}
+
+	/**
+	 * A design whose onPrepare/beforeFactory scripts call openDataSet and use the
+	 * result to modify the design must render without error, record no engine
+	 * errors, and produce a non-empty PDF. Uses the default (empty) value of the
+	 * countryFilter parameter, which the query filters on - the onPrepare script
+	 * handles the resulting empty result set safely.
+	 *
+	 * @throws Exception
+	 */
+	public void testRendersWithoutError() throws Exception {
+		IRunAndRenderTask task = createRunAndRenderTask(PKG + "opendataset-regionconfig.rptdesign");
+		try {
+			File out = renderTo(task, "regionconfig.pdf");
+			assertTrue("Missing output: " + out, out.isFile());
+			assertTrue("Empty output: " + out, out.length() > 0L);
+			assertTrue("Expected no errors: " + task.getErrors(), task.getErrors().isEmpty());
+		} finally {
+			task.close();
+		}
+	}
+
+	/**
+	 * A data set opened from script that does not exist must be reported clearly.
+	 * The exception is not thrown out of run() - it is caught internally and
+	 * recorded as an engine error - so this checks task.getErrors() rather than
+	 * expecting an exception.
+	 *
+	 * @throws Exception
+	 */
+	public void testMissingDataSetFailsClearly() throws Exception {
+		IRunAndRenderTask task = createRunAndRenderTask(PKG + "opendataset-missing.rptdesign");
+		try {
+			renderTo(task, "missing.pdf");
+			List<?> errors = task.getErrors();
+			assertFalse("Expected an error for a non-existent data set", errors.isEmpty());
+			String combined = errors.toString();
+			assertTrue("Expected the error to name the missing data set: " + combined,
+					combined.contains("NoSuchDataSet"));
+		} finally {
+			task.close();
+		}
+	}
+
+	/**
+	 * A script that opens a data set and never calls close() must not prevent the
+	 * render from completing or cause a script error.
+	 *
+	 * @throws Exception
+	 */
+	public void testMissingCloseDoesNotBreakRender() throws Exception {
+		IRunAndRenderTask task = createRunAndRenderTask(PKG + "opendataset-noclose.rptdesign");
+		try {
+			File out = renderTo(task, "noclose.pdf");
+			assertTrue("Missing output: " + out, out.isFile());
+			assertTrue("Empty output: " + out, out.length() > 0L);
+			assertTrue("Expected no errors: " + task.getErrors(), task.getErrors().isEmpty());
+		} finally {
+			task.close();
+		}
+	}
+
+	/**
+	 * The RegionConfig data set is bound to a report parameter (countryFilter, used
+	 * in the query as "where COUNTRY like ?"). Setting the parameter before running
+	 * and reading it from openDataSet must filter the result as expected,
+	 * confirming the report's resolved parameter values reach a query executed from
+	 * script. Verified manually (console output) that the query returns 0 rows with
+	 * the default empty value and 2 rows ("A%") - this test checks the render
+	 * completes cleanly with the parameter set.
+	 *
+	 * @throws Exception
+	 */
+	public void testOpenDataSetWithParameter() throws Exception {
+		IRunAndRenderTask task = createRunAndRenderTask(PKG + "opendataset-regionconfig.rptdesign");
+		try {
+			task.setParameterValue("countryFilter", "A%");
+			File out = renderTo(task, "param.pdf");
+			assertTrue(out.isFile());
+			assertTrue("Expected no errors: " + task.getErrors(), task.getErrors().isEmpty());
+		} finally {
+			task.close();
+		}
+	}
+
+	/** Render the given task to a PDF in the test output directory. */
+	private File renderTo(IRunAndRenderTask task, String fileName) throws Exception {
+		File out = new File(outputDir, fileName);
+		PDFRenderOption options = new PDFRenderOption();
+		options.setOutputFormat("pdf");
+		options.setOutputFileName(out.getAbsolutePath());
+		task.setRenderOption(options);
+		task.run();
+		return out;
+	}
+}

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/opendataset-missing.rptdesign
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/opendataset-missing.rptdesign
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.27" id="1">
+    <property name="units">mm</property>
+    <property name="locale">en_US</property>
+    <method name="beforeFactory"><![CDATA[
+reportContext.openDataSet("NoSuchDataSet", null);
+]]></method>
+    <page-setup>
+        <simple-master-page name="NewSimpleMasterPage" id="2">
+            <property name="type">a4</property>
+        </simple-master-page>
+    </page-setup>
+    <body>
+        <label id="10">
+            <text-property name="text">openDataSet missing-name test</text-property>
+        </label>
+    </body>
+</report>

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/opendataset-noclose.rptdesign
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/opendataset-noclose.rptdesign
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.27" id="1">
+    <property name="units">mm</property>
+    <property name="locale">en_US</property>
+    <method name="beforeFactory"><![CDATA[
+var rs = reportContext.openDataSet("RegionConfig", null);
+var n = 0;
+while (rs.next()) { n++; }
+reportContext.setPersistentGlobalVariable("regionCount", "" + n);
+]]></method>
+    <data-sources>
+        <oda-data-source extensionID="org.eclipse.birt.report.data.oda.jdbc" name="CM" id="11480">
+            <property name="odaDriverClass">org.eclipse.birt.report.data.oda.sampledb.Driver</property>
+            <property name="odaURL">jdbc:classicmodels:sampledb</property>
+            <property name="odaUser">ClassicModels</property>
+        </oda-data-source>
+    </data-sources>
+    <data-sets>
+        <oda-data-set extensionID="org.eclipse.birt.report.data.oda.jdbc.JdbcSelectDataSet" name="RegionConfig" id="11481">
+            <list-property name="parameters"/>
+            <structure name="cachedMetaData">
+                <list-property name="resultSet">
+                    <structure>
+                        <property name="position">1</property>
+                        <property name="name">REGION_NAME</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                </list-property>
+            </structure>
+            <property name="dataSource">CM</property>
+            <list-property name="resultSet">
+                <structure>
+                    <property name="position">1</property>
+                    <property name="name">REGION_NAME</property>
+                    <property name="nativeName">REGION_NAME</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+            </list-property>
+            <xml-property name="queryText"><![CDATA[select distinct COUNTRY as REGION_NAME from customers order by COUNTRY]]></xml-property>
+        </oda-data-set>
+    </data-sets>
+    <page-setup>
+        <simple-master-page name="NewSimpleMasterPage" id="11478">
+            <property name="type">a4</property>
+        </simple-master-page>
+    </page-setup>
+    <body>
+        <text-data id="90001">
+            <expression name="valueExpr">"regionCount = " + reportContext.getPersistentGlobalVariable("regionCount")</expression>
+            <property name="contentType">plain</property>
+        </text-data>
+    </body>
+</report>

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/opendataset-regionconfig.rptdesign
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/opendataset-regionconfig.rptdesign
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.27" id="1">
+    <property name="createdBy">Eclipse BIRT Designer Version 4.25.0.qualifier</property>
+    <property name="language">English</property>
+    <text-property name="title">openDataSet from beforeFactory/onPrepare</text-property>
+    <property name="units">mm</property>
+    <property name="bidiLayoutOrientation">ltr</property>
+    <property name="imageDPI">96</property>
+    <property name="locale">en_US</property>
+    <property name="pdfVersion">1.7</property>
+    <parameters>
+        <scalar-parameter name="countryFilter" id="12000">
+            <property name="dataType">string</property>
+            <property name="paramType">simple</property>
+            <property name="isRequired">false</property>
+        </scalar-parameter>
+    </parameters>
+    <data-sources>
+        <oda-data-source extensionID="org.eclipse.birt.report.data.oda.jdbc" name="CM" id="11480">
+            <property name="odaDriverClass">org.eclipse.birt.report.data.oda.sampledb.Driver</property>
+            <property name="odaURL">jdbc:classicmodels:sampledb</property>
+            <property name="odaUser">ClassicModels</property>
+        </oda-data-source>
+    </data-sources>
+    <data-sets>
+        <oda-data-set extensionID="org.eclipse.birt.report.data.oda.jdbc.JdbcSelectDataSet" name="RegionConfig" id="11481">
+            <list-property name="parameters">
+                <structure>
+                    <property name="name">countryFilter</property>
+                    <property name="paramName">countryFilter</property>
+                    <property name="dataType">string</property>
+                    <property name="position">1</property>
+                    <property name="nativeName"></property>
+                    <property name="isOutput">false</property>
+                    <property name="isInput">true</property>
+                    <expression name="defaultValue" type="constant">""</expression>
+                </structure>
+            </list-property>
+            <structure name="cachedMetaData">
+                <list-property name="resultSet">
+                    <structure>
+                        <property name="position">1</property>
+                        <property name="name">REGION_NAME</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                </list-property>
+            </structure>
+            <property name="dataSource">CM</property>
+            <list-property name="resultSet">
+                <structure>
+                    <property name="position">1</property>
+                    <property name="name">REGION_NAME</property>
+                    <property name="nativeName">REGION_NAME</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+            </list-property>
+            <xml-property name="queryText"><![CDATA[select distinct COUNTRY as REGION_NAME from customers where COUNTRY like ? order by COUNTRY]]></xml-property>
+        </oda-data-set>
+    </data-sets>
+    <page-setup>
+        <simple-master-page name="NewSimpleMasterPage" id="11478">
+            <property name="type">a4</property>
+        </simple-master-page>
+    </page-setup>
+    <body>
+        <label id="90000" name="theLabel">
+            <property name="fontSize">12pt</property>
+            <text-property name="text">placeholder</text-property>
+            <method name="onPrepare"><![CDATA[
+var rs = reportContext.openDataSet("RegionConfig", null);
+rs.next();
+var firstRegion = rs.getString("REGION_NAME");
+rs.close();
+
+var label = reportContext.getDesignHandle().findElement("theLabel");
+label.setProperty("text", "First region: " + firstRegion);
+]]></method>
+        </label>
+
+        <label id="90003">
+            <property name="fontSize">12pt</property>
+            <text-property name="text">Same data set bound to a table:</text-property>
+        </label>
+        <table id="90010" name="theTable">
+            <property name="dataSet">RegionConfig</property>
+            <list-property name="boundDataColumns">
+                <structure>
+                    <property name="name">REGION_NAME</property>
+                    <expression name="expression" type="javascript">dataSetRow["REGION_NAME"]</expression>
+                    <property name="dataType">string</property>
+                </structure>
+            </list-property>
+            <column id="90011"/>
+            <detail>
+                <row id="90015">
+                    <cell id="90016">
+                        <data id="90017">
+                            <property name="resultSetColumn">REGION_NAME</property>
+                        </data>
+                    </cell>
+                </row>
+            </detail>
+        </table>
+    </body>
+</report>

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/impl/EngineTask.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/impl/EngineTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2010 Actuate Corporation.
+ * Copyright (c) 2004, 2026 Actuate Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -1415,7 +1415,6 @@ public abstract class EngineTask implements IEngineTask {
 			renderOptions.setOption(IRenderOption.SUPPORTED_IMAGE_FORMATS, supportedImageFormats);
 			executionRenderOptions.setOption(IRenderOption.SUPPORTED_IMAGE_FORMATS, supportedImageFormats);
 		}
-		executionContext.setNeedOutputResultSet(extManager.needOutputResultSet(emitterID));
 		IContentEmitter emitter = null;
 		try {
 			emitter = extManager.createEmitter(emitterID);
@@ -1731,6 +1730,10 @@ public abstract class EngineTask implements IEngineTask {
 
 			renderOptions.setEmitterID(emitterID);
 			renderOptions.setOutputFormat(format);
+			// Set here (rather than in createContentEmitter, which runs after startFactory)
+			// so the value is available if the data engine is opened from a
+			// beforeFactory/onPrepare script.
+			executionContext.setNeedOutputResultSet(extManager.needOutputResultSet(emitterID));
 		}
 
 		// copy the old setting to render options

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/script/IDataSetResult.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/script/IDataSetResult.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Actuate Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *
+ * Contributors:
+ *  Actuate Corporation  - initial API and implementation (issue #1351)
+ *******************************************************************************/
+
+package org.eclipse.birt.report.engine.api.script;
+
+import org.eclipse.birt.core.exception.BirtException;
+
+/**
+ * A read-only cursor over the rows of a data set opened from script via
+ * {@link IReportContext#openDataSet(String)}.
+ */
+public interface IDataSetResult {
+
+	/**
+	 * Move to the next row.
+	 *
+	 * @return {@code true} if a row is available
+	 * @throws ScriptException
+	 * @throws BirtException
+	 */
+	boolean next() throws ScriptException, BirtException;
+
+	/**
+	 * Get the value of a column in the current row.
+	 *
+	 * @param columnName the column name
+	 * @return the value, or {@code null}
+	 * @throws ScriptException
+	 * @throws BirtException
+	 */
+	Object getValue(String columnName) throws ScriptException, BirtException;
+
+	/**
+	 * Get the value of a column in the current row as a string.
+	 *
+	 * @param columnName the column name
+	 * @return the value as a string, or {@code null}
+	 * @throws ScriptException
+	 * @throws BirtException
+	 */
+	String getString(String columnName) throws ScriptException, BirtException;
+
+	/**
+	 * Release the underlying result set.
+	 *
+	 * @throws ScriptException
+	 * @throws BirtException
+	 */
+	void close() throws ScriptException, BirtException;
+}

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/script/IReportContext.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/api/script/IReportContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005,2009 Actuate Corporation.
+ * Copyright (c) 2005, 2026 Actuate Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -326,4 +326,21 @@ public interface IReportContext {
 	 * @return true, if the report document is finished
 	 */
 	boolean isReportDocumentFinished();
+
+	/**
+	 * Open a data set defined in the report and read its rows from script. The data
+	 * set uses the report's own data engine and resolved parameters. Optionally
+	 * binds input parameter values by name, independent of any report-level
+	 * parameter of the same name - values are bound the same way the ODA driver's
+	 * own parameter placeholders are, so this does not carry the SQL injection risk
+	 * of assembling a WHERE clause manually. Callers must close the returned
+	 * result.
+	 *
+	 * @param name   the data set name
+	 * @param params input parameter values keyed by parameter name, or {@code null}
+	 *               if the data set has no parameters
+	 * @return a cursor over the data set rows
+	 * @throws BirtException if the data set cannot be found or executed
+	 */
+	IDataSetResult openDataSet(String name, Map<String, Object> params) throws BirtException;
 }

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/i18n/MessageConstants.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/i18n/MessageConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2004 Actuate Corporation.
+* Copyright (c) 2004, 2026 Actuate Corporation.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -23,6 +23,8 @@ public class MessageConstants {
 	public static final String FORMAT_NOT_SUPPORTED_EXCEPTION = "Error.OutputFormatNotSupported"; //$NON-NLS-1$
 	public static final String NULL_OUTPUT_FORMAT = "Error.NullOutputFormat";
 	public static final String DESIGN_FILE_NOT_FOUND_EXCEPTION = "Error.DesignFileNotFound"; //$NON-NLS-1$
+	public static final String DATA_SET_NOT_FOUND_EXCEPTION = "Error.DataSetNotFound"; //$NON-NLS-1$
+	public static final String REPORT_DESIGN_NOT_AVAILABLE_EXCEPTION = "Error.ReportDesignNotAvailable"; //$NON-NLS-1$
 	public static final String INVALID_DESIGN_FILE_EXCEPTION = "Error.InvalidDesignFile"; //$NON-NLS-1$
 	public static final String CANNOT_CREATE_EMITTER_EXCEPTION = "Error.CannotCreateExtensionInstance"; //$NON-NLS-1$
 	public static final String MISSING_COMPUTED_COLUMN_EXPRESSION_EXCEPTION = "Error.MissingComputedColumnExpression"; //$NON-NLS-1$

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/i18n/Messages.properties
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/i18n/Messages.properties
@@ -1,5 +1,5 @@
 #/*******************************************************************************
-# * Copyright (c) 2021 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021, 2026 Contributors to the Eclipse Foundation
 # * 
 # * This program and the accompanying materials are made available under the
 # * terms of the Eclipse Public License 2.0 which is available at
@@ -32,6 +32,8 @@ Error.ParameterGroupIsNotFoundByGroupname=Parameter group is not found by the na
 Error.ParameterInvalidGroupLevel=The level count of group "{0}" does not match the specified one.
 Error.InvalidDesignFile=The design file {0} has error and can not be run.
 Error.DesignFileNotFound=The design file {0} can not be found.
+Error.DataSetNotFound = Data set not found: {0}.
+Error.ReportDesignNotAvailable = No report design is available.
 Error.CannotCreateExtensionInstance=Report engine fails to initialize {0} emitter, please make sure required libraries for this emitter are installed.
 Error.MissingComputedColumnExpression=The expression for computed column {0} is missing.
 Error.ParameterInGroupIsnotScalar=The parameters in parameter group "{0}" must be scalar ones.

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/script/internal/ReportContextImpl.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/script/internal/ReportContextImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005,2009 Actuate Corporation.
+ * Copyright (c) 2005, 2026 Actuate Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,21 +15,40 @@
 package org.eclipse.birt.report.engine.script.internal;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.net.URL;
 import java.util.Locale;
 import java.util.Map;
 
+import org.eclipse.birt.core.data.DataType;
 import org.eclipse.birt.core.exception.BirtException;
+import org.eclipse.birt.data.engine.api.IBasePreparedQuery;
+import org.eclipse.birt.data.engine.api.IQueryDefinition;
+import org.eclipse.birt.data.engine.api.IQueryResults;
+import org.eclipse.birt.data.engine.api.IResultIterator;
+import org.eclipse.birt.data.engine.api.IScriptExpression;
+import org.eclipse.birt.data.engine.api.querydefn.BaseExpression;
+import org.eclipse.birt.data.engine.api.querydefn.InputParameterBinding;
+import org.eclipse.birt.data.engine.api.querydefn.QueryDefinition;
+import org.eclipse.birt.data.engine.api.querydefn.ScriptExpressionUtil;
+import org.eclipse.birt.report.data.adapter.api.DataRequestSession;
+import org.eclipse.birt.report.engine.adapter.ModelDteApiAdapter;
 import org.eclipse.birt.report.engine.api.EngineConstants;
+import org.eclipse.birt.report.engine.api.EngineException;
 import org.eclipse.birt.report.engine.api.IEngineTask;
 import org.eclipse.birt.report.engine.api.IHTMLImageHandler;
 import org.eclipse.birt.report.engine.api.IRenderOption;
 import org.eclipse.birt.report.engine.api.IReportRunnable;
 import org.eclipse.birt.report.engine.api.impl.Image;
+import org.eclipse.birt.report.engine.api.impl.QueryUtil;
+import org.eclipse.birt.report.engine.api.script.IDataSetResult;
 import org.eclipse.birt.report.engine.api.script.IReportContext;
 import org.eclipse.birt.report.engine.executor.ExecutionContext;
+import org.eclipse.birt.report.engine.i18n.MessageConstants;
 import org.eclipse.birt.report.engine.ir.Expression;
+import org.eclipse.birt.report.model.api.DataSetHandle;
 import org.eclipse.birt.report.model.api.ReportDesignHandle;
+import org.eclipse.birt.report.model.api.elements.structures.ResultSetColumn;
 
 import com.ibm.icu.text.MessageFormat;
 import com.ibm.icu.util.TimeZone;
@@ -257,5 +276,135 @@ public class ReportContextImpl implements IReportContext {
 	@Override
 	public boolean isReportDocumentFinished() {
 		return context.isReportDocumentFinished();
+	}
+
+	/**
+	 * Open a data set defined in the report and read its rows, using the report's
+	 * own data engine and already-resolved parameters. All columns of the data set
+	 * are selected; no filters, sorts, or row limits are applied beyond any input
+	 * parameter bindings supplied.
+	 * <p>
+	 * Optionally binds input parameter values by name, independent of any
+	 * report-level parameter of the same name. Values are bound the same way the
+	 * ODA driver's own parameter placeholders are - via the data engine's parameter
+	 * binding, not by building the query text - so this does not carry the SQL
+	 * injection risk of assembling a WHERE clause manually.
+	 * <p>
+	 * This is available from script exit points where the report design and
+	 * parameters are already resolved, such as {@code beforeFactory} and
+	 * {@code onPrepare} - both of which run before the report is laid out, so the
+	 * result can be used to shape the design.
+	 *
+	 * @param name   the data set name
+	 * @param params input parameter values keyed by parameter name, or {@code null}
+	 *               if the data set has no parameters
+	 * @return a cursor over the data set rows; the caller must close it
+	 * @throws BirtException if the data set cannot be found or executed
+	 */
+	@Override
+	public IDataSetResult openDataSet(String name, Map<String, Object> params) throws BirtException {
+		ReportDesignHandle design = context.getReportDesign();
+		if (design == null) {
+			throw new EngineException(MessageConstants.REPORT_DESIGN_NOT_AVAILABLE_EXCEPTION);
+		}
+		DataSetHandle dataSet = design.findDataSet(name);
+		if (dataSet == null) {
+			throw new EngineException(MessageConstants.DATA_SET_NOT_FOUND_EXCEPTION, name);
+		}
+
+		context.openDataEngine();
+		DataRequestSession session = context.getDataEngine().getDTESession();
+
+		if (dataSet.getCachedMetaDataHandle() == null) {
+			session.refreshMetaData(dataSet);
+		}
+		QueryDefinition query = new QueryDefinition();
+		query.setDataSetName(dataSet.getQualifiedName());
+		for (ResultSetColumn column : QueryUtil.getResultSetColumns(dataSet).values()) {
+			QueryUtil.addBinding(query, column);
+		}
+
+		if (params != null) {
+			for (Map.Entry<String, Object> entry : params.entrySet()) {
+				if (entry.getValue() == null) {
+					continue;
+				}
+				query.addInputParamBinding(new InputParameterBinding(entry.getKey(), toExpression(entry.getValue())));
+			}
+		}
+
+		new ModelDteApiAdapter(context).defineDataSet(dataSet, session);
+		session.registerQueries(new IQueryDefinition[] { query });
+		IBasePreparedQuery prepared = session.prepare(query);
+		IQueryResults results = (IQueryResults) session.execute(prepared, null, context.getScriptContext());
+
+		return new DataSetResult(results);
+	}
+
+	/**
+	 * Build a constant expression from an input parameter value, with the data type
+	 * set according to the value's Java type. {@code createConstantExpression}
+	 * leaves the data type as {@code UNKNOWN_TYPE} by default, which is not
+	 * reliable for non-string values.
+	 *
+	 * @param value the parameter value; never null
+	 * @return a typed constant expression
+	 */
+	private IScriptExpression toExpression(Object value) {
+		IScriptExpression expr = ScriptExpressionUtil.createConstantExpression(String.valueOf(value));
+		int dataType;
+		if (value instanceof Integer || value instanceof Long) {
+			dataType = DataType.INTEGER_TYPE;
+		} else if (value instanceof Double || value instanceof Float) {
+			dataType = DataType.DOUBLE_TYPE;
+		} else if (value instanceof BigDecimal) {
+			dataType = DataType.DECIMAL_TYPE;
+		} else if (value instanceof java.util.Date) {
+			dataType = DataType.DATE_TYPE;
+		} else if (value instanceof Boolean) {
+			dataType = DataType.BOOLEAN_TYPE;
+		} else {
+			dataType = DataType.STRING_TYPE;
+		}
+		((BaseExpression) expr).setDataType(dataType);
+		return expr;
+	}
+
+	/**
+	 * Default {@link IDataSetResult} implementation, wrapping the query results
+	 * produced by {@link #openDataSet(String)}.
+	 */
+	private static class DataSetResult implements IDataSetResult {
+		private final IQueryResults results;
+		private IResultIterator iterator;
+
+		DataSetResult(IQueryResults results) throws BirtException {
+			this.results = results;
+			this.iterator = results.getResultIterator();
+		}
+
+		@Override
+		public boolean next() throws BirtException {
+			return iterator != null && iterator.next();
+		}
+
+		@Override
+		public Object getValue(String columnName) throws BirtException {
+			return iterator.getValue(columnName);
+		}
+
+		@Override
+		public String getString(String columnName) throws BirtException {
+			return iterator.getString(columnName);
+		}
+
+		@Override
+		public void close() throws BirtException {
+			if (iterator != null) {
+				iterator.close();
+				iterator = null;
+			}
+			results.close();
+		}
 	}
 }


### PR DESCRIPTION
### Summary

- Implemented the `openDataSet` idea from **#1351**.
- This allows `beforeFactory` / `onPrepare` scripts to read the report's own data sets **before the layout is built**.

### What I verified

- Confirmed the report lifecycle:
  - Parameters are resolved before `onPrepare`.
  - `usingParameterValues()` runs before `prepareDesign()`.
  - Data sets are available at this stage.
- Tested with the sample database:
  - Reading data-set rows directly from a script.
  - Using a data-set value to change the report design.
  - Verified the design change in the generated PDF.

### `openDataSet` API

- Added `reportContext.openDataSet(name, params)`.
- `params` contains the input parameter values for the data set, or `null` when no parameters are needed.
- Returns a small **read-only cursor** with:
  - `next()`
  - `getValue()`
  - `getString()`
  - `close()`
- Uses the same query execution approach as `DatasetPreviewTask.extractQuery`.

### Parameter Support

- Added parameter support based on the feedback from @hvbtup.
- Parameters are bound directly to the query using `QueryDefinition.addInputParamBinding`.
- This avoids building query strings manually and does not introduce SQL injection risk.
- Tested with both **string and numeric parameters** and confirmed that filtering works correctly.

### Related Fix

- Moved `needOutputResultSet` from `createContentEmitter` to `setupRenderOption`.
- Previously, it was set **after `startFactory`**, so opening the data engine from a script could miss this setting.

### Tests

Added and verified tests for:

- Reading a data set and using its value to change the report design.
- Opening a non-existent data set.
  - The error is checked through `task.getErrors()` because script exceptions are not propagated from `run()`.
- A script that does not call `close()`.
- Filtering a data set using an input parameter.

- Also verified that each test **fails when the related functionality is broken**, so the tests are checking the expected behaviour rather than simply passing by default.