### PR TITLE
adding exportDataWithColumnName checkbox added for enabling header export along with data/Value

### DIFF
--- a/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/dialog/SimpleExportDataDialogFragment.jsp
+++ b/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/dialog/SimpleExportDataDialogFragment.jsp
@@ -275,6 +275,12 @@
 							<label for="exportDataWithCR"><%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.carriage_return" )%></label>
 						</TD>
 					</TR>
+					<TR>
+						<TD><INPUT TYPE="checkbox" ID="exportDataWithColumnName"></TD>
+						<TD nowrap="nowrap">
+							<label for="exportDataWithColumnName"><%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.column.name" )%></label>
+						</TD>
+					</TR>
 				</TABLE>
 			</DIV>
 		</TD>

--- a/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/dialog/SimpleExportDataDialogFragment.jsp
+++ b/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/dialog/SimpleExportDataDialogFragment.jsp
@@ -250,35 +250,32 @@
 			<DIV>
 				<TABLE cellpadding="0" cellspacing="0">
 					<TR>
-						<TD><INPUT TYPE="checkbox" ID="exportDataWithColumnDisplayName" checked=true></TD>
-						<TD nowrap="nowrap">
-							<label for="exportDataWithColumnDisplayName"><%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.column.display.name" )%></label>
-						</TD>
-						<TD style="padding-left:20px;"><INPUT TYPE="checkbox" ID="exportDataWithColumnName"></TD>
-						<TD nowrap="nowrap">
-							<label for="exportDataWithColumnName"><%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.column.name" )%></label>
-						</TD>
-					</TR>
-					<TR >
 						<TD><INPUT TYPE="checkbox" ID="exportColumnDataType"></TD>
 						<TD>
 							<label for="exportColumnDataType"><%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.datatype" )%></label>
 						</TD>
-						<TD style="padding-left:20px;" ><INPUT TYPE="checkbox" ID="exportColumnLocaleNeutral"></TD>
-						<TD rowspan="2" valign="top" style="padding-top:3px;">
-							<label for="exportColumnLocaleNeutral"><%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.localeneutral" )%></label>
+						<TD style="padding-left:20px;">
+							<INPUT TYPE="checkbox" ID="exportColumnLocaleNeutral">
+						</TD>
+						<TD>
+							<label for="exportColumnLocaleNeutral">
+								<%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.localeneutral" )%>
+							</label>
 						</TD>
 					</TR>
+
 					<TR>
 						<TD><INPUT TYPE="checkbox" ID="exportDataWithCR"></TD>
 						<TD nowrap="nowrap">
 							<label for="exportDataWithCR"><%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.carriage_return" )%></label>
 						</TD>
-					</TR>
-					<TR>
-						<TD><INPUT TYPE="checkbox" ID="exportDataWithColumnName"></TD>
+						<TD style="padding-left:20px;">
+							<INPUT TYPE="checkbox" ID="exportDataWithColumnName" checked="checked">
+						</TD>
 						<TD nowrap="nowrap">
-							<label for="exportDataWithColumnName"><%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.column.name" )%></label>
+							<label for="exportDataWithColumnName">
+								<%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.column.name" )%>
+							</label>
 						</TD>
 					</TR>
 				</TABLE>

--- a/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/dialog/SimpleExportDataDialogFragment.jsp
+++ b/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/dialog/SimpleExportDataDialogFragment.jsp
@@ -258,9 +258,7 @@
 							<INPUT TYPE="checkbox" ID="exportColumnLocaleNeutral">
 						</TD>
 						<TD>
-							<label for="exportColumnLocaleNeutral">
-								<%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.localeneutral" )%>
-							</label>
+							<label for="exportColumnLocaleNeutral"> <%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.localeneutral" )%></label>
 						</TD>
 					</TR>
 
@@ -273,9 +271,7 @@
 							<INPUT TYPE="checkbox" ID="exportDataWithColumnName" checked="checked">
 						</TD>
 						<TD nowrap="nowrap">
-							<label for="exportDataWithColumnName">
-								<%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.column.name" )%>
-							</label>
+							<label for="exportDataWithColumnName"><%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.column.name" )%></label>
 						</TD>
 					</TR>
 				</TABLE>

--- a/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/dialog/SimpleExportDataDialogFragment.jsp
+++ b/viewer/org.eclipse.birt.report.viewer/birt/webcontent/birt/pages/dialog/SimpleExportDataDialogFragment.jsp
@@ -268,7 +268,7 @@
 							<label for="exportDataWithCR"><%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.carriage_return" )%></label>
 						</TD>
 						<TD style="padding-left:20px;">
-							<INPUT TYPE="checkbox" ID="exportDataWithColumnName" checked="checked">
+							<INPUT TYPE="checkbox" ID="exportDataWithColumnName">
 						</TD>
 						<TD nowrap="nowrap">
 							<label for="exportDataWithColumnName"><%= BirtResources.getMessage( "birt.viewer.dialog.exportdata.column.name" )%></label>


### PR DESCRIPTION
exportDataWithColumnName checkbox absent when exporting the data in CSV. Resulting in missing of header column in exported CSV report.

Environment

OS: [e.g., Windows, macOS, Linux]
Browser: [e.g., Chrome, Firefox]
BIRT Version: [e.g., 4.21.0]
Screenshots

Image - before fix
<img width="591" height="507" alt="Screenshot 2026-08-26 at 2 19 20 PM" src="https://github.com/user-attachments/assets/4567eba2-41e4-4d0f-9437-c1f6d49dd34a" />

Additional Context
result before fix
<img width="1005" height="383" alt="Screenshot 2026-08-26 at 2 20 15 PM" src="https://github.com/user-attachments/assets/91f15d6f-7f41-4ecc-bac0-d55aea249655" />

Image - after Fix

<img width="590" height="517" alt="Screenshot 2026-08-26 at 2 26 19 PM" src="https://github.com/user-attachments/assets/976c7bd7-211e-466a-82d2-3f317bee6b47" />


result After fix
<img width="999" height="84" alt="Screenshot 2026-08-26 at 2 27 24 PM" src="https://github.com/user-attachments/assets/086de8e8-21f8-49ec-8455-5804a835e834" />
