### PR TITLE
Fix invalid PDF/UA tag structure for Drop: Detail cells

### DIFF
--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/PdfRenderTest.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/PdfRenderTest.java
@@ -23,7 +23,7 @@ import org.eclipse.birt.report.engine.api.PDFRenderOption;
 public class PdfRenderTest extends EngineCase {
 	public void testRenderReport() throws Exception {
 		String thePackage = "test/org/eclipse/birt/report/engine/emitter/pdf/";
-		String[] designs = { "issue-2429", "issue-2445", "issue-2446", "issue-2454", "issue-2466" };
+		String[] designs = { "issue-2429", "issue-2445", "issue-2446", "issue-2454", "issue-2458", "issue-2466" };
 		String suffix = ".rptdesign";
 		PDFRenderOption options = new PDFRenderOption();
 		options.setOutputFormat("pdf");

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/issue-2458.rptdesign
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf.tests/test/org/eclipse/birt/report/engine/emitter/pdf/issue-2458.rptdesign
@@ -1,0 +1,782 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.27" id="1">
+    <property name="author">Henning von Bargen</property>
+    <property name="createdBy">Eclipse BIRT Designer Version 4.25.0.v202608160751</property>
+    <property name="language">English</property>
+    <text-property name="title">BIRT Issue 2429</text-property>
+    <property name="units">mm</property>
+    <property name="iconFile">/templates/blank_report.gif</property>
+    <property name="bidiLayoutOrientation">ltr</property>
+    <property name="imageDPI">96</property>
+    <property name="locale">en_US</property>
+    <property name="pdfVersion">1.7</property>
+    <property name="pdfUAConformance">PDF.UA-1</property>
+    <data-sources>
+        <oda-data-source extensionID="org.eclipse.birt.report.data.oda.jdbc" name="CM" id="11480">
+            <list-property name="privateDriverProperties">
+                <ex-property>
+                    <name>contentBidiFormatStr</name>
+                    <value>ILYNN</value>
+                </ex-property>
+                <ex-property>
+                    <name>metadataBidiFormatStr</name>
+                    <value>ILYNN</value>
+                </ex-property>
+            </list-property>
+            <property name="odaDriverClass">org.eclipse.birt.report.data.oda.sampledb.Driver</property>
+            <property name="odaURL">jdbc:classicmodels:sampledb</property>
+            <property name="odaUser">ClassicModels</property>
+        </oda-data-source>
+    </data-sources>
+    <data-sets>
+        <oda-data-set extensionID="org.eclipse.birt.report.data.oda.jdbc.JdbcSelectDataSet" name="Productlines" id="11481">
+            <list-property name="columnHints">
+                <structure>
+                    <property name="columnName">PRODUCTLINE</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">PRODUCTLINE</text-property>
+                    <text-property name="heading">PRODUCTLINE</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">TEXTDESCRIPTION</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">TEXTDESCRIPTION</text-property>
+                    <text-property name="heading">TEXTDESCRIPTION</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">HTMLDESCRIPTION</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">HTMLDESCRIPTION</text-property>
+                    <text-property name="heading">HTMLDESCRIPTION</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">IMAGE</property>
+                    <property name="analysis">attribute</property>
+                    <text-property name="displayName">IMAGE</text-property>
+                    <text-property name="heading">IMAGE</text-property>
+                </structure>
+            </list-property>
+            <list-property name="parameters"/>
+            <structure name="cachedMetaData">
+                <list-property name="resultSet">
+                    <structure>
+                        <property name="position">1</property>
+                        <property name="name">PRODUCTLINE</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">2</property>
+                        <property name="name">TEXTDESCRIPTION</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">3</property>
+                        <property name="name">HTMLDESCRIPTION</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">4</property>
+                        <property name="name">IMAGE</property>
+                        <property name="dataType">blob</property>
+                    </structure>
+                </list-property>
+            </structure>
+            <property name="dataSource">CM</property>
+            <list-property name="resultSet">
+                <structure>
+                    <property name="position">1</property>
+                    <property name="name">PRODUCTLINE</property>
+                    <property name="nativeName">PRODUCTLINE</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">2</property>
+                    <property name="name">TEXTDESCRIPTION</property>
+                    <property name="nativeName">TEXTDESCRIPTION</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">3</property>
+                    <property name="name">HTMLDESCRIPTION</property>
+                    <property name="nativeName">HTMLDESCRIPTION</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">2005</property>
+                </structure>
+                <structure>
+                    <property name="position">4</property>
+                    <property name="name">IMAGE</property>
+                    <property name="nativeName">IMAGE</property>
+                    <property name="dataType">blob</property>
+                    <property name="nativeDataType">2004</property>
+                </structure>
+            </list-property>
+            <xml-property name="queryText"><![CDATA[select *
+from productlines
+]]></xml-property>
+            <xml-property name="designerValues"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+<model:DesignValues xmlns:design="http://www.eclipse.org/datatools/connectivity/oda/design" xmlns:model="http://www.eclipse.org/birt/report/model/adapter/odaModel">
+  <Version>2.0</Version>
+  <design:ResultSets derivedMetaData="true">
+    <design:resultSetDefinitions>
+      <design:resultSetColumns>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>PRODUCTLINE</design:name>
+              <design:position>1</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>12</design:nativeDataTypeCode>
+            <design:precision>50</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>PRODUCTLINE</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>PRODUCTLINE</design:label>
+            <design:formattingHints>
+              <design:displaySize>50</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+      </design:resultSetColumns>
+      <design:criteria/>
+    </design:resultSetDefinitions>
+  </design:ResultSets>
+</model:DesignValues>]]></xml-property>
+        </oda-data-set>
+        <oda-data-set extensionID="org.eclipse.birt.report.data.oda.jdbc.JdbcSelectDataSet" name="Products" id="11482">
+            <list-property name="columnHints">
+                <structure>
+                    <property name="columnName">PRODUCTCODE</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">PRODUCTCODE</text-property>
+                    <text-property name="heading">PRODUCTCODE</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">PRODUCTNAME</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">PRODUCTNAME</text-property>
+                    <text-property name="heading">PRODUCTNAME</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">PRODUCTLINE</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">PRODUCTLINE</text-property>
+                    <text-property name="heading">PRODUCTLINE</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">PRODUCTSCALE</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">PRODUCTSCALE</text-property>
+                    <text-property name="heading">PRODUCTSCALE</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">PRODUCTVENDOR</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">PRODUCTVENDOR</text-property>
+                    <text-property name="heading">PRODUCTVENDOR</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">PRODUCTDESCRIPTION</property>
+                    <property name="analysis">dimension</property>
+                    <text-property name="displayName">PRODUCTDESCRIPTION</text-property>
+                    <text-property name="heading">PRODUCTDESCRIPTION</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">QUANTITYINSTOCK</property>
+                    <property name="analysis">measure</property>
+                    <text-property name="displayName">QUANTITYINSTOCK</text-property>
+                    <text-property name="heading">QUANTITYINSTOCK</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">BUYPRICE</property>
+                    <property name="analysis">measure</property>
+                    <text-property name="displayName">BUYPRICE</text-property>
+                    <text-property name="heading">BUYPRICE</text-property>
+                </structure>
+                <structure>
+                    <property name="columnName">MSRP</property>
+                    <property name="analysis">measure</property>
+                    <text-property name="displayName">MSRP</text-property>
+                    <text-property name="heading">MSRP</text-property>
+                </structure>
+            </list-property>
+            <list-property name="parameters">
+                <structure>
+                    <property name="name">param_Productline</property>
+                    <property name="nativeName"></property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                    <property name="position">1</property>
+                    <expression name="defaultValue" type="javascript">""</expression>
+                    <property name="isOptional">true</property>
+                    <property name="allowNull">true</property>
+                    <property name="isInput">true</property>
+                    <property name="isOutput">false</property>
+                </structure>
+            </list-property>
+            <structure name="cachedMetaData">
+                <list-property name="resultSet">
+                    <structure>
+                        <property name="position">1</property>
+                        <property name="name">PRODUCTCODE</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">2</property>
+                        <property name="name">PRODUCTNAME</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">3</property>
+                        <property name="name">PRODUCTLINE</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">4</property>
+                        <property name="name">PRODUCTSCALE</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">5</property>
+                        <property name="name">PRODUCTVENDOR</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">6</property>
+                        <property name="name">PRODUCTDESCRIPTION</property>
+                        <property name="dataType">string</property>
+                    </structure>
+                    <structure>
+                        <property name="position">7</property>
+                        <property name="name">QUANTITYINSTOCK</property>
+                        <property name="dataType">integer</property>
+                    </structure>
+                    <structure>
+                        <property name="position">8</property>
+                        <property name="name">BUYPRICE</property>
+                        <property name="dataType">float</property>
+                    </structure>
+                    <structure>
+                        <property name="position">9</property>
+                        <property name="name">MSRP</property>
+                        <property name="dataType">float</property>
+                    </structure>
+                </list-property>
+            </structure>
+            <property name="dataSource">CM</property>
+            <list-property name="resultSet">
+                <structure>
+                    <property name="position">1</property>
+                    <property name="name">PRODUCTCODE</property>
+                    <property name="nativeName">PRODUCTCODE</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">2</property>
+                    <property name="name">PRODUCTNAME</property>
+                    <property name="nativeName">PRODUCTNAME</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">3</property>
+                    <property name="name">PRODUCTLINE</property>
+                    <property name="nativeName">PRODUCTLINE</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">4</property>
+                    <property name="name">PRODUCTSCALE</property>
+                    <property name="nativeName">PRODUCTSCALE</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">5</property>
+                    <property name="name">PRODUCTVENDOR</property>
+                    <property name="nativeName">PRODUCTVENDOR</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">6</property>
+                    <property name="name">PRODUCTDESCRIPTION</property>
+                    <property name="nativeName">PRODUCTDESCRIPTION</property>
+                    <property name="dataType">string</property>
+                    <property name="nativeDataType">12</property>
+                </structure>
+                <structure>
+                    <property name="position">7</property>
+                    <property name="name">QUANTITYINSTOCK</property>
+                    <property name="nativeName">QUANTITYINSTOCK</property>
+                    <property name="dataType">integer</property>
+                    <property name="nativeDataType">4</property>
+                </structure>
+                <structure>
+                    <property name="position">8</property>
+                    <property name="name">BUYPRICE</property>
+                    <property name="nativeName">BUYPRICE</property>
+                    <property name="dataType">float</property>
+                    <property name="nativeDataType">8</property>
+                </structure>
+                <structure>
+                    <property name="position">9</property>
+                    <property name="name">MSRP</property>
+                    <property name="nativeName">MSRP</property>
+                    <property name="dataType">float</property>
+                    <property name="nativeDataType">8</property>
+                </structure>
+            </list-property>
+            <xml-property name="queryText"><![CDATA[select *
+from products
+where productline = ?]]></xml-property>
+            <xml-property name="designerValues"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+<model:DesignValues xmlns:design="http://www.eclipse.org/datatools/connectivity/oda/design" xmlns:model="http://www.eclipse.org/birt/report/model/adapter/odaModel">
+  <Version>2.0</Version>
+  <DataSetParameters>
+    <parameter>
+      <design:ParameterDefinition>
+        <design:inOutMode>In</design:inOutMode>
+        <design:attributes>
+          <design:identifier>
+            <design:name></design:name>
+            <design:position>1</design:position>
+          </design:identifier>
+          <design:nativeDataTypeCode>12</design:nativeDataTypeCode>
+          <design:precision>50</design:precision>
+          <design:scale>0</design:scale>
+          <design:nullability>Nullable</design:nullability>
+        </design:attributes>
+        <design:inputAttributes>
+          <design:elementAttributes>
+            <design:optional>true</design:optional>
+          </design:elementAttributes>
+        </design:inputAttributes>
+      </design:ParameterDefinition>
+    </parameter>
+  </DataSetParameters>
+  <design:ResultSets derivedMetaData="true">
+    <design:resultSetDefinitions>
+      <design:resultSetColumns>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>PRODUCTCODE</design:name>
+              <design:position>1</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>12</design:nativeDataTypeCode>
+            <design:precision>15</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>PRODUCTCODE</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>PRODUCTCODE</design:label>
+            <design:formattingHints>
+              <design:displaySize>15</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>PRODUCTNAME</design:name>
+              <design:position>2</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>12</design:nativeDataTypeCode>
+            <design:precision>70</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>PRODUCTNAME</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>PRODUCTNAME</design:label>
+            <design:formattingHints>
+              <design:displaySize>70</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>PRODUCTLINE</design:name>
+              <design:position>3</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>12</design:nativeDataTypeCode>
+            <design:precision>50</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>PRODUCTLINE</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>PRODUCTLINE</design:label>
+            <design:formattingHints>
+              <design:displaySize>50</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>PRODUCTSCALE</design:name>
+              <design:position>4</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>12</design:nativeDataTypeCode>
+            <design:precision>10</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>PRODUCTSCALE</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>PRODUCTSCALE</design:label>
+            <design:formattingHints>
+              <design:displaySize>10</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>PRODUCTVENDOR</design:name>
+              <design:position>5</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>12</design:nativeDataTypeCode>
+            <design:precision>50</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>PRODUCTVENDOR</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>PRODUCTVENDOR</design:label>
+            <design:formattingHints>
+              <design:displaySize>50</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>PRODUCTDESCRIPTION</design:name>
+              <design:position>6</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>12</design:nativeDataTypeCode>
+            <design:precision>32700</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>PRODUCTDESCRIPTION</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>PRODUCTDESCRIPTION</design:label>
+            <design:formattingHints>
+              <design:displaySize>32700</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>QUANTITYINSTOCK</design:name>
+              <design:position>7</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>4</design:nativeDataTypeCode>
+            <design:precision>10</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>QUANTITYINSTOCK</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>QUANTITYINSTOCK</design:label>
+            <design:formattingHints>
+              <design:displaySize>11</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>BUYPRICE</design:name>
+              <design:position>8</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>8</design:nativeDataTypeCode>
+            <design:precision>15</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>BUYPRICE</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>BUYPRICE</design:label>
+            <design:formattingHints>
+              <design:displaySize>24</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+        <design:resultColumnDefinitions>
+          <design:attributes>
+            <design:identifier>
+              <design:name>MSRP</design:name>
+              <design:position>9</design:position>
+            </design:identifier>
+            <design:nativeDataTypeCode>8</design:nativeDataTypeCode>
+            <design:precision>15</design:precision>
+            <design:scale>0</design:scale>
+            <design:nullability>Nullable</design:nullability>
+            <design:uiHints>
+              <design:displayName>MSRP</design:displayName>
+            </design:uiHints>
+          </design:attributes>
+          <design:usageHints>
+            <design:label>MSRP</design:label>
+            <design:formattingHints>
+              <design:displaySize>24</design:displaySize>
+            </design:formattingHints>
+          </design:usageHints>
+        </design:resultColumnDefinitions>
+      </design:resultSetColumns>
+      <design:criteria/>
+    </design:resultSetDefinitions>
+  </design:ResultSets>
+</model:DesignValues>]]></xml-property>
+        </oda-data-set>
+    </data-sets>
+    <styles>
+        <style name="report" id="11479">
+            <property name="fontFamily">"Noto Sans"</property>
+        </style>
+    </styles>
+    <page-setup>
+        <simple-master-page name="NewSimpleMasterPage" id="11478">
+            <property name="type">a4</property>
+        </simple-master-page>
+    </page-setup>
+    <body>
+        <label id="11509">
+            <property name="fontWeight">bold</property>
+            <property name="marginBottom">12pt</property>
+            <text-property name="text">Drop: Detail with PDF/UA</text-property>
+        </label>
+        <list id="11557">
+            <property name="dataSet">Productlines</property>
+            <list-property name="boundDataColumns">
+                <structure>
+                    <property name="name">PRODUCTLINE</property>
+                    <text-property name="displayName">PRODUCTLINE</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["PRODUCTLINE"]</expression>
+                    <property name="dataType">string</property>
+                </structure>
+                <structure>
+                    <property name="name">TEXTDESCRIPTION</property>
+                    <text-property name="displayName">TEXTDESCRIPTION</text-property>
+                    <expression name="expression" type="javascript">dataSetRow["TEXTDESCRIPTION"]</expression>
+                    <property name="dataType">string</property>
+                </structure>
+            </list-property>
+            <detail>
+                <data id="11558">
+                    <property name="resultSetColumn">PRODUCTLINE</property>
+                    <property name="tagType">H1</property>
+                </data>
+                <data id="11559">
+                    <property name="resultSetColumn">TEXTDESCRIPTION</property>
+                    <property name="tagType">P</property>
+                </data>
+                <table name="Products" id="11511">
+                    <property name="dataSet">Products</property>
+                    <list-property name="paramBindings">
+                        <structure>
+                            <property name="paramName">param_Productline</property>
+                            <simple-property-list name="expression">
+                                <value type="javascript">row["PRODUCTLINE"]</value>
+                            </simple-property-list>
+                        </structure>
+                    </list-property>
+                    <list-property name="boundDataColumns">
+                        <structure>
+                            <property name="name">PRODUCTCODE</property>
+                            <text-property name="displayName">PRODUCTCODE</text-property>
+                            <expression name="expression" type="javascript">dataSetRow["PRODUCTCODE"]</expression>
+                            <property name="dataType">string</property>
+                        </structure>
+                        <structure>
+                            <property name="name">PRODUCTNAME</property>
+                            <text-property name="displayName">PRODUCTNAME</text-property>
+                            <expression name="expression" type="javascript">dataSetRow["PRODUCTNAME"]</expression>
+                            <property name="dataType">string</property>
+                        </structure>
+                        <structure>
+                            <property name="name">PRODUCTLINE</property>
+                            <text-property name="displayName">PRODUCTLINE</text-property>
+                            <expression name="expression" type="javascript">dataSetRow["PRODUCTLINE"]</expression>
+                            <property name="dataType">string</property>
+                        </structure>
+                        <structure>
+                            <property name="name">PRODUCTSCALE</property>
+                            <text-property name="displayName">PRODUCTSCALE</text-property>
+                            <expression name="expression" type="javascript">dataSetRow["PRODUCTSCALE"]</expression>
+                            <property name="dataType">string</property>
+                        </structure>
+                        <structure>
+                            <property name="name">PRODUCTVENDOR</property>
+                            <text-property name="displayName">PRODUCTVENDOR</text-property>
+                            <expression name="expression" type="javascript">dataSetRow["PRODUCTVENDOR"]</expression>
+                            <property name="dataType">string</property>
+                        </structure>
+                        <structure>
+                            <property name="name">PRODUCTDESCRIPTION</property>
+                            <text-property name="displayName">PRODUCTDESCRIPTION</text-property>
+                            <expression name="expression" type="javascript">dataSetRow["PRODUCTDESCRIPTION"]</expression>
+                            <property name="dataType">string</property>
+                        </structure>
+                        <structure>
+                            <property name="name">QUANTITYINSTOCK</property>
+                            <text-property name="displayName">QUANTITYINSTOCK</text-property>
+                            <expression name="expression" type="javascript">dataSetRow["QUANTITYINSTOCK"]</expression>
+                            <property name="dataType">integer</property>
+                        </structure>
+                    </list-property>
+                    <column id="11553">
+                        <property name="repeat">1</property>
+                        <property name="width">20mm</property>
+                    </column>
+                    <column id="11554">
+                        <property name="repeat">1</property>
+                        <property name="width">40mm</property>
+                    </column>
+                    <column id="11551">
+                        <property name="width">40mm</property>
+                    </column>
+                    <column id="11550">
+                        <property name="repeat">1</property>
+                        <property name="width">25mm</property>
+                    </column>
+                    <column id="11555"/>
+                    <header>
+                        <row id="11512">
+                            <property name="tagType">TR</property>
+                            <cell id="11519">
+                                <property name="scope">col</property>
+                                <label id="11520">
+                                    <text-property name="text">Scale</text-property>
+                                </label>
+                            </cell>
+                            <cell id="11521">
+                                <property name="scope">col</property>
+                                <label id="11522">
+                                    <text-property name="text">Vendor</text-property>
+                                </label>
+                            </cell>
+                            <cell id="11515">
+                                <property name="scope">col</property>
+                                <label id="11516">
+                                    <text-property name="text">Name</text-property>
+                                </label>
+                            </cell>
+                            <cell id="11513">
+                                <property name="scope">col</property>
+                                <label id="11514">
+                                    <text-property name="text">Code</text-property>
+                                </label>
+                            </cell>
+                            <cell id="11523">
+                                <property name="scope">col</property>
+                                <label id="11524">
+                                    <text-property name="text">Description</text-property>
+                                </label>
+                            </cell>
+                        </row>
+                    </header>
+                    <group id="11560">
+                        <property name="groupName">TG_Scale</property>
+                        <expression name="keyExpr" type="javascript">row["PRODUCTSCALE"]</expression>
+                        <structure name="toc">
+                            <expression name="expressionValue" type="javascript">row["PRODUCTSCALE"]</expression>
+                        </structure>
+                        <property name="hideDetail">false</property>
+                        <header>
+                            <row id="11561">
+                                <cell id="11562">
+                                    <property name="drop">detail</property>
+                                    <property name="scope">col</property>
+                                    <data id="11575">
+                                        <property name="resultSetColumn">PRODUCTSCALE</property>
+                                    </data>
+                                </cell>
+                                <cell id="11563"/>
+                                <cell id="11564"/>
+                                <cell id="11565"/>
+                                <cell id="11566"/>
+                            </row>
+                        </header>
+                    </group>
+                    <group id="11576">
+                        <property name="groupName">TG_Vendor</property>
+                        <expression name="keyExpr" type="javascript">row["PRODUCTVENDOR"]</expression>
+                        <structure name="toc">
+                            <expression name="expressionValue" type="javascript">row["PRODUCTVENDOR"]</expression>
+                        </structure>
+                        <property name="hideDetail">false</property>
+                        <header>
+                            <row id="11577">
+                                <cell id="11578"/>
+                                <cell id="11579">
+                                    <property name="drop">detail</property>
+                                    <property name="scope">col</property>
+                                    <data id="11591">
+                                        <property name="resultSetColumn">PRODUCTVENDOR</property>
+                                    </data>
+                                </cell>
+                                <cell id="11580"/>
+                                <cell id="11581"/>
+                                <cell id="11582"/>
+                            </row>
+                        </header>
+                    </group>
+                    <detail>
+                        <row id="11527">
+                            <property name="tagType">TR</property>
+                            <cell id="11534"/>
+                            <cell id="11536"/>
+                            <cell id="11530">
+                                <data id="11531">
+                                    <property name="resultSetColumn">PRODUCTNAME</property>
+                                </data>
+                            </cell>
+                            <cell id="11528">
+                                <data id="11529">
+                                    <property name="resultSetColumn">PRODUCTCODE</property>
+                                </data>
+                            </cell>
+                            <cell id="11538">
+                                <data id="11539">
+                                    <property name="resultSetColumn">PRODUCTDESCRIPTION</property>
+                                </data>
+                            </cell>
+                        </row>
+                    </detail>
+                </table>
+            </detail>
+        </list>
+    </body>
+</report>

--- a/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPageDevice.java
+++ b/engine/org.eclipse.birt.report.engine.emitter.pdf/src/org/eclipse/birt/report/engine/emitter/pdf/PDFPageDevice.java
@@ -41,8 +41,8 @@ import org.eclipse.birt.report.engine.api.ITOCTree;
 import org.eclipse.birt.report.engine.api.TOCNode;
 import org.eclipse.birt.report.engine.api.script.IReportContext;
 import org.eclipse.birt.report.engine.content.IBandContent;
+import org.eclipse.birt.report.engine.content.ICellContent;
 import org.eclipse.birt.report.engine.content.IReportContent;
-import org.eclipse.birt.report.engine.content.impl.CellContent;
 import org.eclipse.birt.report.engine.content.impl.RowContent;
 import org.eclipse.birt.report.engine.i18n.EngineResourceHandle;
 import org.eclipse.birt.report.engine.i18n.MessageConstants;
@@ -1570,19 +1570,29 @@ public class PDFPageDevice implements IPageDevice {
 							}
 						}
 					} else {
-						structureCurrentNode = container.getFirstPart().getStructureElement();
-						PdfName restored = structureCurrentNode.getAsName(PdfName.S);
-						if (PdfName.TABLE.equals(restored)) {
-							// Also restore the table section, e.g. TBody.
-							// K may be a single PdfDictionary (first page) or a PdfArray
-							// (subsequent pages). Handle both cases.
-							PdfArray children = structureCurrentNode.getAsArray(PdfName.K);
-							if (children != null && children.size() > 0) {
-								structureCurrentNode = (PdfStructureElement) children.getAsDict(children.size() - 1);
-							} else {
-								PdfObject singleChild = structureCurrentNode.get(PdfName.K);
-								if (singleChild instanceof PdfStructureElement) {
-									structureCurrentNode = (PdfStructureElement) singleChild;
+						PdfStructureElement firstPartElement = container.getFirstPart() == null ? null :
+							container.getFirstPart().getStructureElement();
+						if (firstPartElement == null) {
+							if (PdfTag.TR.equals(tagType)) {
+								beforeOpenTableSectionTag(container);
+							}
+							PdfStructureElement created = safeCreateStructureElement(structureCurrentNode, new PdfName(tagType));
+							if (created != null) {
+								structureCurrentNode = created;
+							}
+						} else {
+							structureCurrentNode = firstPartElement;
+							PdfName restored = structureCurrentNode.getAsName(PdfName.S);
+							if (PdfName.TABLE.equals(restored)) {
+								PdfArray children = structureCurrentNode.getAsArray(PdfName.K);
+								if (children != null && children.size() > 0) {
+									structureCurrentNode = (PdfStructureElement) children
+											.getAsDict(children.size() - 1);
+								} else {
+									PdfObject singleChild = structureCurrentNode.get(PdfName.K);
+									if (singleChild instanceof PdfStructureElement) {
+										structureCurrentNode = (PdfStructureElement) singleChild;
+									}
 								}
 							}
 						}
@@ -1695,15 +1705,17 @@ public class PDFPageDevice implements IPageDevice {
 	private void addTableCellAttributes(String tagType, IArea area) {
 		if (area instanceof CellArea) {
 			CellArea cellArea = (CellArea) area;
-			int rowspan = cellArea.getRowSpan();
-			int colspan = cellArea.getColSpan();
-			String scope = ((CellContent) (cellArea.getContent())).getScope();
+			// A row/col span can never be less than 1 in a valid PDF/UA table structure.
+			// but guard against writing an invalid attribute.
+			int rowspan = Math.max(1, cellArea.getRowSpan());
+			int colspan = Math.max(1, cellArea.getColSpan());
+			String scope = ((ICellContent) (cellArea.getContent())).getScope();
 			String bookmark = cellArea.getBookmark();
 			if (bookmark != null) {
 				structureCurrentNode.put(PdfName.ID, new PdfString(bookmark));
 			}
 
-			String headers = ((CellContent) (cellArea.getContent())).getHeaders();
+			String headers = ((ICellContent) (cellArea.getContent())).getHeaders();
 			if (rowspan != 1 || colspan != 1 || scope != null || headers != null) {
 				PdfDictionary attributes = structureCurrentNode.getAsDict(PdfName.A);
 				if (attributes == null) {

--- a/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/internal/content/wrap/AbstractContentWrapper.java
+++ b/engine/org.eclipse.birt.report.engine/src/org/eclipse/birt/report/engine/internal/content/wrap/AbstractContentWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004,2009 Actuate Corporation.
+ * Copyright (c) 2004,2026 Actuate Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -577,19 +577,17 @@ abstract public class AbstractContentWrapper extends AbstractElement implements 
 		content.setExtensions(properties);
 	}
 
-	private String tagType = null;
-
 	/**
 	 * @return Returns the tagType.
 	 */
 	public String getTagType() {
-		return tagType;
+		return content.getTagType();
 	}
 
 	/**
 	 * @param tagType The tagType to set.
 	 */
 	public void setTagType(String tagType) {
-		this.tagType = tagType;
+		content.setTagType(tagType);
 	}
 }


### PR DESCRIPTION
## What

Fixes an issue with the PDF/UA tagging for tables that contain a `Drop: Detail` or `Drop: All` cell.

## Root cause

While looking into the issue, I found that `AbstractContentWrapper.getTagType()` and `setTagType()` were not forwarding the tag type to the wrapped content.

This is different from how the other properties in the class work. For tables with a drop cell, the cell content goes through this wrapper, so the tag type was getting lost along the way. As a result, the cells were not getting the expected `TD`/`TH` tags.

I also found a `ClassCastException` in `PDFPageDevice`. The code was casting the cell content directly to `CellContent` instead of using the `ICellContent` interface. Once the tag type was being passed through correctly, this code path could receive a wrapped content instance, which caused the cast to fail.

## Verification

I reproduced the issue locally and rendered the PDF/UA output before and after the fix. I then checked the `/StructTreeRoot` structure.

* **Before:** The rows were ending up as untagged cells, with no `TD`/`TH` tags.
* **After:** The cells are correctly tagged as `TD`/`TH`, and the drop cell's `RowSpan` correctly covers its full extent.
* I also tested two tables without drop cells to make sure the changes didn't introduce any regression.

Fixes #2458
